### PR TITLE
Added 3 optional parameters to TweetEntityUrlV2

### DIFF
--- a/src/types/entities.types.ts
+++ b/src/types/entities.types.ts
@@ -8,10 +8,6 @@ export interface UrlEntity extends Entity {
   url: string; // https;//t.co/...
   expanded_url: string; // https://unfollow.ninja/
   display_url: string; // unfollow.ninja
-  status?: string; // "200", present only on urls with previews
-  title?: string //Unfollow Ninja, present only on urls with previews
-  description?: string //peut signifier que..., present only on urls with previews
-  unwound_url?: string //https://unfollow.ninja/, present only on urls with previews
 }
 
 export interface HashtagEntity extends Entity {

--- a/src/types/entities.types.ts
+++ b/src/types/entities.types.ts
@@ -8,6 +8,10 @@ export interface UrlEntity extends Entity {
   url: string; // https;//t.co/...
   expanded_url: string; // https://unfollow.ninja/
   display_url: string; // unfollow.ninja
+  status?: string; // "200", present only on urls with previews
+  title?: string //Unfollow Ninja, present only on urls with previews
+  description?: string //peut signifier que..., present only on urls with previews
+  unwound_url?: string //https://unfollow.ninja/, present only on urls with previews
 }
 
 export interface HashtagEntity extends Entity {

--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -94,6 +94,9 @@ export interface TweetEntityUrlV2 {
   expanded_url: string;
   display_url: string;
   unwound_url: string;
+  status?: string;
+  title?: string;
+  description?: string;
 }
 
 export interface TweetEntityHashtagV2 {


### PR DESCRIPTION
Added three optional parameters to TweetEntityUrlV2

```
status?: string;
title?: string;
description?: string;
```

These parameters are returned along with others when the URL contains valid OG tags. These properties show up in URL preview cards on Twitter UI. For reference, check "urls" in "entities" in the description column for the field value "entities" in this [Twiter API Documentaion](https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet).

Also, my first PR 🥳 