### PR TITLE
Added 4 optional paramerters in TweetEntityUrlV2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "test-stream": "npm run mocha test/stream.test.ts",
     "test-media": "npm run mocha test/media-upload.test.ts",
     "test-auth": "npm run mocha test/auth.test.ts",
-    "prepublish": "npm run build",
-    "prepare": "npm run build"
+    "prepublish": "npm run build"
   },
   "repository": "github:plhery/node-twitter-api-v2",
   "author": "Paul-Louis Hery <paullouis.hery+twitterapi@gmail.com> (https://twitter.com/plhery)",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test-stream": "npm run mocha test/stream.test.ts",
     "test-media": "npm run mocha test/media-upload.test.ts",
     "test-auth": "npm run mocha test/auth.test.ts",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "prepare": "npm run build"
   },
   "repository": "github:plhery/node-twitter-api-v2",
   "author": "Paul-Louis Hery <paullouis.hery+twitterapi@gmail.com> (https://twitter.com/plhery)",

--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -94,6 +94,14 @@ export interface TweetEntityUrlV2 {
   expanded_url: string;
   display_url: string;
   unwound_url: string;
+  title?: string;
+  description?: string;
+  status?: string;
+  images?: {
+    url: string;
+    width: number;
+    height: number;
+  }
 }
 
 export interface TweetEntityHashtagV2 {


### PR DESCRIPTION
Added 4 optional parameters to TweetEntityUrlV2

```yaml
title?: string;
description?: string;
status?: string;
images?: {
    url: string;
    width: number;
    height: number;
}
```


These parameters are returned along with others when the URL contains valid OG tags. These properties show up in URL preview cards on Twitter UI. For reference, check "urls" in "entities" in the description column for the field value "entities" in this [Twiter API Documentaion](https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet). Note that `image` parameter is not shown in the example but can be seen in the actual response from the API.