### PR TITLE
Fixed handling of empy results in TweetTimelineV2Paginator

### DIFF
--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -51,7 +51,7 @@ abstract class TweetTimelineV2Paginator<
   }
 
   protected getPageLengthFromRequest(result: TwitterResponse<TResult>) {
-    return result.data.data.length;
+    return result.data?.data?.length||0;
   }
 
   protected isFetchLastOver(result: TwitterResponse<TResult>) {

--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -55,7 +55,7 @@ abstract class TweetTimelineV2Paginator<
   }
 
   protected isFetchLastOver(result: TwitterResponse<TResult>) {
-    return !result.data.data.length || !result.data.meta.next_token;
+    return !result.data?.data?.length || !result.data.meta.next_token;
   }
 
   protected getItemArray() {

--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -19,17 +19,18 @@ abstract class TweetTimelineV2Paginator<
   protected refreshInstanceFromResult(response: TwitterResponse<TResult>, isNextPage: boolean) {
     const result = response.data;
     this._rateLimit = response.rateLimit!;
-
-    if (isNextPage) {
-      this._realData.meta.oldest_id = result.meta.oldest_id;
-      this._realData.meta.result_count += result.meta.result_count;
-      this._realData.meta.next_token = result.meta.next_token;
-      this._realData.data.push(...result.data);
-    }
-    else {
-      this._realData.meta.newest_id = result.meta.newest_id;
-      this._realData.meta.result_count += result.meta.result_count;
-      this._realData.data.unshift(...result.data);
+    if (result.data) {
+      if (isNextPage) {
+        this._realData.meta.oldest_id = result.meta.oldest_id
+        this._realData.meta.result_count += result.meta.result_count
+        this._realData.meta.next_token = result.meta.next_token
+        this._realData.data.push(...result.data)
+      }
+      else {
+        this._realData.meta.newest_id = result.meta.newest_id
+        this._realData.meta.result_count += result.meta.result_count
+        this._realData.data.unshift(...result.data)
+      }
     }
   }
 

--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -18,19 +18,19 @@ abstract class TweetTimelineV2Paginator<
 > extends PreviousableTwitterPaginator<TResult, TParams, TweetV2, TShared> {
   protected refreshInstanceFromResult(response: TwitterResponse<TResult>, isNextPage: boolean) {
     const result = response.data;
+    const resultData = result.data ?? [];
     this._rateLimit = response.rateLimit!;
-    if (result.data) {
-      if (isNextPage) {
-        this._realData.meta.oldest_id = result.meta.oldest_id
-        this._realData.meta.result_count += result.meta.result_count
-        this._realData.meta.next_token = result.meta.next_token
-        this._realData.data.push(...result.data)
-      }
-      else {
-        this._realData.meta.newest_id = result.meta.newest_id
-        this._realData.meta.result_count += result.meta.result_count
-        this._realData.data.unshift(...result.data)
-      }
+
+    if (isNextPage) {
+      this._realData.meta.oldest_id = result.meta.oldest_id;
+      this._realData.meta.result_count += result.meta.result_count;
+      this._realData.meta.next_token = result.meta.next_token;
+      this._realData.data.push(...resultData);
+    }
+    else {
+      this._realData.meta.newest_id = result.meta.newest_id;
+      this._realData.meta.result_count += result.meta.result_count;
+      this._realData.data.unshift(...resultData);
     }
   }
 
@@ -51,11 +51,11 @@ abstract class TweetTimelineV2Paginator<
   }
 
   protected getPageLengthFromRequest(result: TwitterResponse<TResult>) {
-    return result.data?.data?.length||0;
+    return result.data.data?.length ?? 0;
   }
 
   protected isFetchLastOver(result: TwitterResponse<TResult>) {
-    return !result.data?.data?.length || !result.data.meta.next_token;
+    return !result.data.data?.length || !result.data.meta.next_token;
   }
 
   protected getItemArray() {


### PR DESCRIPTION
When using `fetchLast` on `twitterClient.v2.userTimeline`, it throws the following error.

```
(node:64827) UnhandledPromiseRejectionWarning: TypeError: result.data is not iterable (cannot read property undefined)
    at TweetUserTimelineV2Paginator.refreshInstanceFromResult (XXX/node_modules/twitter-api-v2/dist/paginators/tweet.paginator.v2.js:14:33)
    at TweetUserTimelineV2Paginator.fetchLast (XXX/node_modules/twitter-api-v2/dist/paginators/TwitterPaginator.js:69:24)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:64827) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:64827) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```


Turns out the reason is the way "last page" is checked in [TwitterPaginator.fetchLast](https://github.com/PLhery/node-twitter-api-v2/blob/fb9e47864a3b2b87596547537cf1971a0c27cfae/src/paginators/TwitterPaginator.ts#L116). Here `isFetchLastOver` happens after refreshing instance from result.
```javascript
while (resultCount < count && this._isRateLimitOk) {
      const response = await this.makeRequest(queryParams);
      await this.refreshInstanceFromResult(response, true);

      resultCount += this.getPageLengthFromRequest(response);

      if (this.isFetchLastOver(response)) {
        break;
      }

      queryParams = this.getNextQueryParams(this._maxResultsWhenFetchLast);
    }
```

But when using with `v2.userTimeline`, the second last page contains next_token but last page is doesn't contain any data. API just returns something like in response.data. **(when `count` is more than number of tweets or tweet cap for the endpoint)**.

```javascript
{
  meta: { 
    result_count: 0 
  } 
}
```

We can see that `response.data.data` is empty and when trying to refresh instance in [TweetTimelineV2Paginator.refreshInstanceFromResult](https://github.com/PLhery/node-twitter-api-v2/blob/fb9e47864a3b2b87596547537cf1971a0c27cfae/src/paginators/tweet.paginator.v2.ts#L19), 
`this._realData.data.push(...result.data)` throws an uncaught error.

**Temporary fix** : Check if `response.data.data` is non empty before performing refreshing of instance in `TweetTimelineV2Paginator.refreshInstanceFromResult` so that it looks like this.

```javascript
if (result.data) {
  if (isNextPage) {
    this._realData.meta.oldest_id = result.meta.oldest_id
    this._realData.meta.result_count += result.meta.result_count
    this._realData.meta.next_token = result.meta.next_token
    this._realData.data.push(...result.data)
  }
  else {
    this._realData.meta.newest_id = result.meta.newest_id
    this._realData.meta.result_count += result.meta.result_count
    this._realData.data.unshift(...result.data)
  }
}
```

 We need to update `getPageLengthFromRequest` to handle for the case when `result.data.data` is undefined. So we could use optional chaining and set 0 as fallback value.

```javascript
protected getPageLengthFromRequest(result: TwitterResponse<TResult>) {
  return result.data?.data?.length||0;
}
```

We also need to update `isFetchLastOver` in the same manner.

```javascript
protected isFetchLastOver(result: TwitterResponse<TResult>) {
  return !result.data?.data?.length || !result.data.meta.next_token;
}
```


Fixing it inside` TweetTimelineV2Paginator` would cover this case not just `fetchLast` for for all types of pagination. I haven't checked with v1 yet, might be a good idea to check that once. A better solution would be to check for this inside something like `isFetchLastOver`. But this fix works for now.
    