### PR TITLE
Added a method to get "includes" from v2 paginator 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-api-v2",
-  "version": "0.4.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test-stream": "npm run mocha test/stream.test.ts",
     "test-media": "npm run mocha test/media-upload.test.ts",
     "test-auth": "npm run mocha test/auth.test.ts",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "prepare": "npm run build"
   },
   "repository": "github:plhery/node-twitter-api-v2",
   "author": "Paul-Louis Hery <paullouis.hery+twitterapi@gmail.com> (https://twitter.com/plhery)",

--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -51,7 +51,7 @@ abstract class TweetTimelineV2Paginator<
   }
 
   protected getPageLengthFromRequest(result: TwitterResponse<TResult>) {
-    return result.data.data.length;
+    return result.data?.data?.length||0;
   }
 
   protected isFetchLastOver(result: TwitterResponse<TResult>) {

--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -55,7 +55,7 @@ abstract class TweetTimelineV2Paginator<
   }
 
   protected isFetchLastOver(result: TwitterResponse<TResult>) {
-    return !result.data.data.length || !result.data.meta.next_token;
+    return !result.data?.data?.length || !result.data.meta.next_token;
   }
 
   protected getItemArray() {

--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -19,17 +19,18 @@ abstract class TweetTimelineV2Paginator<
   protected refreshInstanceFromResult(response: TwitterResponse<TResult>, isNextPage: boolean) {
     const result = response.data;
     this._rateLimit = response.rateLimit!;
-
-    if (isNextPage) {
-      this._realData.meta.oldest_id = result.meta.oldest_id;
-      this._realData.meta.result_count += result.meta.result_count;
-      this._realData.meta.next_token = result.meta.next_token;
-      this._realData.data.push(...result.data);
-    }
-    else {
-      this._realData.meta.newest_id = result.meta.newest_id;
-      this._realData.meta.result_count += result.meta.result_count;
-      this._realData.data.unshift(...result.data);
+    if (result.data) {
+      if (isNextPage) {
+        this._realData.meta.oldest_id = result.meta.oldest_id
+        this._realData.meta.result_count += result.meta.result_count
+        this._realData.meta.next_token = result.meta.next_token
+        this._realData.data.push(...result.data)
+      }
+      else {
+        this._realData.meta.newest_id = result.meta.newest_id
+        this._realData.meta.result_count += result.meta.result_count
+        this._realData.data.unshift(...result.data)
+      }
     }
   }
 

--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -68,6 +68,11 @@ abstract class TweetTimelineV2Paginator<
   get tweets() {
     return this._realData.data;
   }
+  
+  //includes object returned by paginator
+  get includes() {
+    return this._realData.includes;
+  }
 }
 
 // ----------------

--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -94,6 +94,14 @@ export interface TweetEntityUrlV2 {
   expanded_url: string;
   display_url: string;
   unwound_url: string;
+  title?: string;
+  description?: string;
+  status?: string;
+  images?: {
+    url: string;
+    width: number;
+    height: number;
+  }
 }
 
 export interface TweetEntityHashtagV2 {


### PR DESCRIPTION
Added the following method in [TweetTimelineV2Paginator](https://github.com/PLhery/node-twitter-api-v2/blob/fb9e47864a3b2b87596547537cf1971a0c27cfae/src/paginators/tweet.paginator.v2.ts#L18)
```javascript
get includes() {
    return this._realData.includes;
  }
```

Now includes object can be obtained just like tweets in paginators.
Eg.
```javascript
const fetchedTweets = homeTimeline.includes;
```

This fix is just for v2 api. Haven't checked v1 yet.