### PR TITLE
API v1.1 Direct Message endpoint wrappers

### DIFF
--- a/doc/v1.md
+++ b/doc/v1.md
@@ -331,6 +331,366 @@ const loggedUser = await client.v1.verifyCredentials();
 const loggedUser = await client.currentUser();
 ```
 
+## Direct Messages (DMs)
+
+### Send a new direct message to someone
+
+**Method**: `.sendDm()`
+
+**Endpoint**: `direct_messages/events/new.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `options: SendDMV1Params`
+
+**Returns**: `DirectMessageCreateV1Result`
+
+**Example**
+```ts
+const recipientId = '12';
+
+const dmSent = await client.v1.sendDm({
+  // Mandatory
+  recipient_id: recipientId,
+  // Other parameters are collapsed into {message_data} of payload
+  text: 'Hello Jack!',
+  attachment: {
+    type: 'media',
+    media: { id: '24024092' },
+  },
+});
+
+dmSent.event[EDirectMessageEventTypeV1.Create].message_data.text === 'Hello Jack!'; // true!
+```
+
+### Get a single DM by ID
+
+**Method**: `.getDmEvent()`
+
+**Endpoint**: `direct_messages/events/show.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `id: string`
+
+**Returns**: `ReceivedDMEventV1`
+
+**Example**
+```ts
+const directMessage = await client.v1.getDmEvent('<DM-ID>');
+
+const messageSender = directMessage.event[EDirectMessageEventTypeV1.Create].sender_id;
+```
+
+### Delete / hide a DM
+
+**Method**: `.deleteDm()`
+
+**Endpoint**: `direct_messages/events/destroy.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `id: string`
+
+**Returns**: `void`
+
+**Example**
+```ts
+await client.v1.deleteDm('<DM-ID>');
+```
+
+### List sent and received DMs
+
+This isn't sorted by conversation, you will get all events *sent* and *received* in any conversation.
+
+**Method**: `.listDmEvents()`
+
+**Endpoint**: `direct_messages/events/list.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**: None.
+
+**Returns**: `DmEventsV1Paginator`
+
+**Example**
+```ts
+const eventsPaginator = await client.v1.listDmEvents();
+
+for await (const event of eventsPaginator) {
+  if (event.type === EDirectMessageEventTypeV1.Create) {
+    console.log('Sender ID is', event[EDirectMessageEventTypeV1.Create].sender_id);
+  }
+}
+```
+
+### Create a welcome direct message
+
+A welcome direct message is a message that will automatically greet users who want to
+interact with the logged account. You must "activate" the welcome direct message by creating
+a "welcome direct message rule" (see below).
+
+**Method**: `.newWelcomeDm()`
+
+**Endpoint**: `direct_messages/welcome_messages/new.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `name: string`
+  - `data: MessageCreateDataV1`: The `message_data` property of the payload.
+
+**Returns**: `WelcomeDirectMessageCreateV1Result`
+
+**Example**
+```ts
+const welcomeDm = await client.v1.newWelcomeDm('welcome dm 1', {
+  text: 'Welcome! Please tell us whats the problem? You can also view your support page.',
+  ctas: [{
+    type: 'web_url',
+    url: 'https://example.com/your_support.php',
+    label: 'Our support page',
+  }],
+});
+
+console.log(welcomeDm[EDirectMessageEventTypeV1.WelcomeCreate].message_data.text);
+```
+
+### Get a welcome direct message (that you own)
+
+A welcome direct message is a message that will automatically greet users who want to
+interact with the logged account.
+
+**Method**: `.getWelcomeDm()`
+
+**Endpoint**: `direct_messages/welcome_messages/show.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `id: string`
+
+**Returns**: `WelcomeDirectMessageCreateV1Result`
+
+**Example**
+```ts
+const welcomeDm = await client.v1.getWelcomeDm('<DM-ID>');
+```
+
+### Delete a welcome direct message (that you own)
+
+**Method**: `.deleteWelcomeDm()`
+
+**Endpoint**: `direct_messages/welcome_messages/destroy.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `id: string`
+
+**Returns**: `void`
+
+**Example**
+```ts
+await client.v1.deleteWelcomeDm(welcomeDm[EDirectMessageEventTypeV1.WelcomeCreate].id);
+```
+
+### Update a welcome direct message (that you own)
+
+**Method**: `.updateWelcomeDm()`
+
+**Endpoint**: `direct_messages/welcome_messages/update.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `id: string`
+  - `data: MessageCreateDataV1`: The `message_data` property of the payload.
+
+**Returns**: `WelcomeDirectMessageCreateV1Result`
+
+**Example**
+```ts
+await client.v1.updateWelcomeDm(welcomeDm[EDirectMessageEventTypeV1.WelcomeCreate].id, {
+  ...welcomeDm[EDirectMessageEventTypeV1.WelcomeCreate].message_data,
+  text: 'Another text for welcome Dm.',
+});
+```
+
+### List your welcome DMs
+
+**Method**: `.listWelcomeDms()`
+
+**Endpoint**: `direct_messages/welcome_messages/list.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**: None.
+
+**Returns**: `WelcomeDmV1Paginator`
+
+**Example**
+```ts
+const welcomeDms = await client.v1.listWelcomeDms();
+
+for await (const welcomeDm of welcomeDms) {
+  console.log(welcomeDm.id, welcomeDm.message_data.text, welcomeDm.name);
+}
+```
+
+---------
+
+### Create a welcome direct message rule
+
+This will "enable" a desired welcome direct message. The related message will automatically show up on new conversations.
+
+***A rule shouldn't already exist!***.
+
+**Method**: `.newWelcomeDmRule()`
+
+**Endpoint**: `direct_messages/welcome_messages/rules/new.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `welcomeMessageId: string`
+
+**Returns**: `WelcomeDmRuleV1Result`
+
+**Example**
+```ts
+const rule = await client.v1.newWelcomeDmRule(welcomeDm[EDirectMessageEventTypeV1.WelcomeCreate].id);
+console.log(rule.welcome_message_rule.id, rule.welcome_message_rule.welcome_message_id);
+```
+
+### Get a welcome direct message rule
+
+**Method**: `.getWelcomeDmRule()`
+
+**Endpoint**: `direct_messages/welcome_messages/rules/show.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `id: string`
+
+**Returns**: `WelcomeDmRuleV1Result`
+
+**Example**
+```ts
+const rule = await client.v1.getWelcomeDmRule(rule.welcome_message_rule.id);
+```
+
+### Delete a welcome direct message rule
+
+**Method**: `.deleteWelcomeDmRule()`
+
+**Endpoint**: `direct_messages/welcome_messages/rules/destroy.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `id: string`
+
+**Returns**: `void`
+
+**Example**
+```ts
+await client.v1.deleteWelcomeDmRule(rule.welcome_message_rule.id);
+```
+
+### List your welcome DM rules
+
+In fact, you can only have one unique rule set. So this endpoint will either return a empty object,
+or an object with a single-element array.
+
+**Method**: `.listWelcomeDmRules()`
+
+**Endpoint**: `direct_messages/welcome_messages/rules/list.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**: None.
+
+**Returns**: `WelcomeDmRuleListV1Result`
+
+**Example**
+```ts
+const rules = await client.v1.listWelcomeDmRules();
+
+if (rules.welcome_message_rules?.length) {
+  const activeRule = rules.welcome_message_rules[0];
+}
+```
+
+### Set the active visible welcome DM
+
+This helper will do the job for you if you want to properly set an active rule given a created welcome message.
+
+It will:
+- List the existing welcome DM rules
+- For each rule, delete the rule *and the associated welcome DM if `deleteAssociatedWelcomeDmWhenDeletingRule` is `true` (default)*.
+- Then, create the new welcome DM rule with the given welcome DM ID.
+
+**Method**: `.setWelcomeDm()`
+
+**Endpoint**: Combinaison of multiple endpoints
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `welcomeMessageId: string`
+  - `deleteAssociatedWelcomeDmWhenDeletingRule?: boolean = true`
+
+**Returns**: `WelcomeDmRuleV1Result`
+
+**Example**
+```ts
+await client.v1.setWelcomeDm(welcomeDm[EDirectMessageEventTypeV1.WelcomeCreate].id);
+```
+
+### Mark a received DM as read in a conversation
+
+**Method**: `.markDmAsRead()`
+
+**Endpoint**: `direct_messages/mark_read.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `lastEventId: string`
+  - `recipientId: string` (recipient of the conversation, not the message!)
+
+**Returns**: `void`
+
+**Example**
+```ts
+const eventData = directMessage.event[EDirectMessageEventTypeV1.Create];
+await client.v1.markDmAsRead(directMessage.event.id, eventData.sender_id);
+```
+
+### Indicate that user is typing in a conversation
+
+**Method**: `.indicateDmTyping()`
+
+**Endpoint**: `direct_messages/indicate_typing.json`
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `recipientId: string` (recipient of the conversation)
+
+**Returns**: `void`
+
+**Example**
+```ts
+const eventData = directMessage.event[EDirectMessageEventTypeV1.Create];
+await client.v1.indicateDmTyping(eventData.sender_id);
+```
+
 
 ## Trends
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,1605 @@
 {
   "name": "twitter-api-v2",
-  "version": "0.4.0",
-  "lockfileVersion": 1,
+  "version": "1.1.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/chai": "^4.2.16",
+        "@types/mocha": "^8.2.2",
+        "@types/node": "^14.14.37",
+        "chai": "^4.3.4",
+        "dotenv": "^8.2.0",
+        "mocha": "^8.3.2",
+        "ts-node": "^9.1.1",
+        "typedoc": "^0.20.35",
+        "typescript": "^4.2.4"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
+      "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
+      "dev": true
+    },
+    "node_modules/@types/mocha": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "14.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+      "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ==",
+      "dev": true
+    },
+    "node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/marked": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.7.tgz",
+      "integrity": "sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">= 8.16.2"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mocha": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+      "dev": true,
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.0.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.3",
+        "nanoid": "3.1.20",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.1.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^5.1.1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.5.tgz",
+      "integrity": "sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.0",
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "5.2.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.20.37",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.37.tgz",
+      "integrity": "sha512-9+qDhdc4X00qTNOtii6QX2z7ndAeWVOso7w3MPSoSJdXlVhpwPfm1yEp4ooKuWA9fiQILR8FKkyjmeqa13hBbw==",
+      "dev": true,
+      "dependencies": {
+        "colors": "^1.4.0",
+        "fs-extra": "^9.1.0",
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
+        "lunr": "^2.3.9",
+        "marked": "~2.0.3",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "shiki": "^0.9.3",
+        "typedoc-default-themes": "^0.12.10"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 10.8.0"
+      },
+      "peerDependencies": {
+        "typescript": "3.9.x || 4.0.x || 4.1.x || 4.2.x"
+      }
+    },
+    "node_modules/typedoc-default-themes": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
+      "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.1.tgz",
+      "integrity": "sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "node_modules/workerpool": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
   "dependencies": {
     "@types/chai": {
-      "version": "4.2.16",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.16.tgz",
-      "integrity": "sha512-vI5iOAsez9+roLS3M3+Xx7w+WRuDtSmF8bQkrbcIJ2sC1PcDgVoA0WGpa+bIrJ+y8zqY2oi//fUctkxtIcXJCw==",
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
+      "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
       "dev": true
     },
     "@types/mocha": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
-      "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "version": "14.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+      "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
@@ -35,9 +1615,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
@@ -147,13 +1727,24 @@
       }
     },
     "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "check-error": {
@@ -189,6 +1780,12 @@
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -289,9 +1886,9 @@
       "dev": true
     },
     "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
       "dev": true
     },
     "emoji-regex": {
@@ -304,6 +1901,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
     "fill-range": {
@@ -475,9 +2078,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -529,6 +2132,15 @@
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
+      }
+    },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
       }
     },
     "jsonfile": {
@@ -587,9 +2199,9 @@
       "dev": true
     },
     "marked": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
-      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.7.tgz",
+      "integrity": "sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==",
       "dev": true
     },
     "minimatch": {
@@ -608,9 +2220,9 @@
       "dev": true
     },
     "mocha": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.2.tgz",
-      "integrity": "sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -638,23 +2250,6 @@
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "ms": {
@@ -730,9 +2325,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "pathval": {
@@ -742,9 +2337,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
     "progress": {
@@ -823,13 +2418,14 @@
       }
     },
     "shiki": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.3.tgz",
-      "integrity": "sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.5.tgz",
+      "integrity": "sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ==",
       "dev": true,
       "requires": {
+        "json5": "^2.2.0",
         "onigasm": "^2.2.5",
-        "vscode-textmate": "^5.2.0"
+        "vscode-textmate": "5.2.0"
       }
     },
     "source-map": {
@@ -865,14 +2461,6 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        }
       }
     },
     "strip-json-comments": {
@@ -882,9 +2470,9 @@
       "dev": true
     },
     "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
@@ -928,9 +2516,9 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.20.35",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.35.tgz",
-      "integrity": "sha512-7sNca19LXg2hgyGHq3b33tQ1YFApmd8aBDEzWQ2ry4VDkw/NdFWkysGiGRY1QckDCB0gVH8+MlXA4K71IB3azg==",
+      "version": "0.20.37",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.37.tgz",
+      "integrity": "sha512-9+qDhdc4X00qTNOtii6QX2z7ndAeWVOso7w3MPSoSJdXlVhpwPfm1yEp4ooKuWA9fiQILR8FKkyjmeqa13hBbw==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",
@@ -938,12 +2526,12 @@
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "^2.0.1",
+        "marked": "~2.0.3",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
         "shiki": "^0.9.3",
-        "typedoc-default-themes": "^0.12.9"
+        "typedoc-default-themes": "^0.12.10"
       }
     },
     "typedoc-default-themes": {
@@ -959,9 +2547,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
-      "integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.1.tgz",
+      "integrity": "sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==",
       "dev": true,
       "optional": true
     },
@@ -972,9 +2560,9 @@
       "dev": true
     },
     "vscode-textmate": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.0.tgz",
-      "integrity": "sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "which": {
@@ -1018,6 +2606,12 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1079,6 +2673,12 @@
         "yargs-parser": "^20.2.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test-stream": "npm run mocha test/stream.test.ts",
     "test-media": "npm run mocha test/media-upload.test.ts",
     "test-auth": "npm run mocha test/auth.test.ts",
+    "test-dm": "npm run mocha test/dm.*.test.ts",
     "prepublish": "npm run build"
   },
   "repository": "github:plhery/node-twitter-api-v2",

--- a/src/paginators/TwitterPaginator.ts
+++ b/src/paginators/TwitterPaginator.ts
@@ -146,15 +146,11 @@ export abstract class TwitterPaginator<TApiResult, TApiParams extends object, TI
     yield* this.getItemArray();
     let paginator = this;
 
-    while (this._isRateLimitOk) {
+    while (this._isRateLimitOk && paginator.getItemArray().length > 0) {
       const next = await paginator.next(this._maxResultsWhenFetchLast);
       this._rateLimit = next._rateLimit;
       const items = next.getItemArray();
       yield* items;
-
-      if (!items.length) {
-        break;
-      }
 
       paginator = next;
     }

--- a/src/paginators/dm.paginator.v1.ts
+++ b/src/paginators/dm.paginator.v1.ts
@@ -1,0 +1,119 @@
+import type { GetDmListV1Args, ReceivedDMEventsV1, TReceivedDMEvent, TwitterResponse, ReceivedWelcomeDMCreateEventV1, WelcomeDirectMessageListV1Result, ReceivedDmCustomProfileV1, ReceivedDmCustomProfileListV1 } from '../types';
+import TwitterPaginator from './TwitterPaginator';
+
+export class DmEventsV1Paginator extends TwitterPaginator<ReceivedDMEventsV1, GetDmListV1Args, TReceivedDMEvent> {
+  protected _endpoint = 'direct_messages/events/list.json';
+
+  protected refreshInstanceFromResult(response: TwitterResponse<ReceivedDMEventsV1>, isNextPage: true) {
+    const result = response.data;
+    this._rateLimit = response.rateLimit!;
+
+    if (isNextPage) {
+      this._realData.events.push(...result.events);
+      this._realData.next_cursor = result.next_cursor;
+    }
+  }
+
+  protected getNextQueryParams(maxResults?: number): GetDmListV1Args {
+    return {
+      ...this._queryParams,
+      cursor: this._realData.next_cursor,
+      ...(maxResults ? { count: maxResults } : {})
+    };
+  }
+
+  protected getPageLengthFromRequest(result: TwitterResponse<ReceivedDMEventsV1>) {
+    return result.data.events.length;
+  }
+
+  protected isFetchLastOver(result: TwitterResponse<ReceivedDMEventsV1>) {
+    return result.data.next_cursor === undefined;
+  }
+
+  protected getItemArray() {
+    return this.events;
+  }
+
+  /**
+   * Events returned by paginator.
+   */
+  get events() {
+    return this._realData.events;
+  }
+}
+
+export class WelcomeDmV1Paginator extends TwitterPaginator<WelcomeDirectMessageListV1Result, GetDmListV1Args, ReceivedWelcomeDMCreateEventV1> {
+  protected _endpoint = 'direct_messages/welcome_messages/list.json';
+
+  protected refreshInstanceFromResult(response: TwitterResponse<WelcomeDirectMessageListV1Result>, isNextPage: true) {
+    const result = response.data;
+    this._rateLimit = response.rateLimit!;
+
+    if (isNextPage) {
+      this._realData.welcome_messages.push(...result.welcome_messages);
+      this._realData.next_cursor = result.next_cursor;
+    }
+  }
+
+  protected getNextQueryParams(maxResults?: number): GetDmListV1Args {
+    return {
+      ...this._queryParams,
+      cursor: this._realData.next_cursor,
+      ...(maxResults ? { count: maxResults } : {})
+    };
+  }
+
+  protected getPageLengthFromRequest(result: TwitterResponse<WelcomeDirectMessageListV1Result>) {
+    return result.data.welcome_messages.length;
+  }
+
+  protected isFetchLastOver(result: TwitterResponse<WelcomeDirectMessageListV1Result>) {
+    return result.data.next_cursor === undefined;
+  }
+
+  protected getItemArray() {
+    return this.welcomeMessages;
+  }
+
+  get welcomeMessages() {
+    return this._realData.welcome_messages;
+  }
+}
+
+export class CustomProfileDmV1Paginator extends TwitterPaginator<ReceivedDmCustomProfileListV1, GetDmListV1Args, ReceivedDmCustomProfileV1> {
+  protected _endpoint = 'custom_profiles/list.json';
+
+  protected refreshInstanceFromResult(response: TwitterResponse<ReceivedDmCustomProfileListV1>, isNextPage: true) {
+    const result = response.data;
+    this._rateLimit = response.rateLimit!;
+
+    if (isNextPage) {
+      this._realData.custom_profiles.push(...result.custom_profiles);
+      this._realData.next_cursor = result.next_cursor;
+    }
+  }
+
+  protected getNextQueryParams(maxResults?: number): GetDmListV1Args {
+    return {
+      ...this._queryParams,
+      cursor: this._realData.next_cursor,
+      ...(maxResults ? { count: maxResults } : {})
+    };
+  }
+
+  protected getPageLengthFromRequest(result: TwitterResponse<ReceivedDmCustomProfileListV1>) {
+    return result.data.custom_profiles.length;
+  }
+
+  protected isFetchLastOver(result: TwitterResponse<ReceivedDmCustomProfileListV1>) {
+    return result.data.next_cursor === undefined;
+  }
+
+  protected getItemArray() {
+    return this.customProfiles;
+  }
+
+  get customProfiles() {
+    return this._realData.custom_profiles;
+  }
+}

--- a/src/paginators/dm.paginator.v1.ts
+++ b/src/paginators/dm.paginator.v1.ts
@@ -1,4 +1,4 @@
-import type { GetDmListV1Args, ReceivedDMEventsV1, TReceivedDMEvent, TwitterResponse, ReceivedWelcomeDMCreateEventV1, WelcomeDirectMessageListV1Result, ReceivedDmCustomProfileV1, ReceivedDmCustomProfileListV1 } from '../types';
+import type { GetDmListV1Args, ReceivedDMEventsV1, TReceivedDMEvent, TwitterResponse, ReceivedWelcomeDMCreateEventV1, WelcomeDirectMessageListV1Result } from '../types';
 import TwitterPaginator from './TwitterPaginator';
 
 export class DmEventsV1Paginator extends TwitterPaginator<ReceivedDMEventsV1, GetDmListV1Args, TReceivedDMEvent> {
@@ -77,43 +77,5 @@ export class WelcomeDmV1Paginator extends TwitterPaginator<WelcomeDirectMessageL
 
   get welcomeMessages() {
     return this._realData.welcome_messages;
-  }
-}
-
-export class CustomProfileDmV1Paginator extends TwitterPaginator<ReceivedDmCustomProfileListV1, GetDmListV1Args, ReceivedDmCustomProfileV1> {
-  protected _endpoint = 'custom_profiles/list.json';
-
-  protected refreshInstanceFromResult(response: TwitterResponse<ReceivedDmCustomProfileListV1>, isNextPage: true) {
-    const result = response.data;
-    this._rateLimit = response.rateLimit!;
-
-    if (isNextPage) {
-      this._realData.custom_profiles.push(...result.custom_profiles);
-      this._realData.next_cursor = result.next_cursor;
-    }
-  }
-
-  protected getNextQueryParams(maxResults?: number): GetDmListV1Args {
-    return {
-      ...this._queryParams,
-      cursor: this._realData.next_cursor,
-      ...(maxResults ? { count: maxResults } : {})
-    };
-  }
-
-  protected getPageLengthFromRequest(result: TwitterResponse<ReceivedDmCustomProfileListV1>) {
-    return result.data.custom_profiles.length;
-  }
-
-  protected isFetchLastOver(result: TwitterResponse<ReceivedDmCustomProfileListV1>) {
-    return result.data.next_cursor === undefined;
-  }
-
-  protected getItemArray() {
-    return this.customProfiles;
-  }
-
-  get customProfiles() {
-    return this._realData.custom_profiles;
   }
 }

--- a/src/types/v1/dm.v1.types.ts
+++ b/src/types/v1/dm.v1.types.ts
@@ -3,7 +3,7 @@ import { CoordinateV1, MediaEntityV1, TweetEntitiesV1 } from './entities.v1.type
 // Creation of DMs
 export enum EDirectMessageEventTypeV1 {
   Create = 'message_create',
-  WelcomeCreate = 'welcome_message_create',
+  WelcomeCreate = 'welcome_message',
 }
 
 export interface MessageCreateEventV1 {
@@ -186,7 +186,7 @@ export interface WelcomeDmRuleV1Result {
 
 export interface WelcomeDmRuleListV1Result {
   next_cursor?: string;
-  welcome_message_rules: WelcomeDmRuleV1[];
+  welcome_message_rules?: WelcomeDmRuleV1[];
 }
 
 // -- Custom profiles --

--- a/src/types/v1/dm.v1.types.ts
+++ b/src/types/v1/dm.v1.types.ts
@@ -25,7 +25,7 @@ export interface MessageCreateCtaV1 {
   type: 'web_url';
   url: string;
   label: string;
-  /** Only when messages are retrived from API */
+  /** Only when messages are retrieved from API */
   tco_url?: string;
 }
 

--- a/src/types/v1/dm.v1.types.ts
+++ b/src/types/v1/dm.v1.types.ts
@@ -1,0 +1,211 @@
+import { CoordinateV1, MediaEntityV1, TweetEntitiesV1 } from './entities.v1.types';
+
+// Creation of DMs
+export enum EDirectMessageEventTypeV1 {
+  Create = 'message_create',
+  WelcomeCreate = 'welcome_message_create',
+}
+
+export interface MessageCreateEventV1 {
+  target: {
+    recipient_id: string;
+  };
+  message_data: MessageCreateDataV1;
+  custom_profile_id?: string;
+}
+
+export interface MessageCreateDataV1 {
+  text: string;
+  attachment?: MessageCreateAttachmentV1;
+  quick_reply?: MessageCreateQuickReplyV1;
+  ctas?: MessageCreateCtaV1[];
+}
+
+export interface MessageCreateCtaV1 {
+  type: 'web_url';
+  url: string;
+  label: string;
+  /** Only when messages are retrived from API */
+  tco_url?: string;
+}
+
+export interface MessageCreateQuickReplyOptionV1 {
+  label: string;
+  description?: string;
+  metadata?: string;
+}
+
+export interface MessageCreateQuickReplyV1 {
+  type: 'options';
+  options: MessageCreateQuickReplyOptionV1[];
+}
+
+export type MessageCreateAttachmentV1 = {
+  type: 'media';
+  media: { id: string };
+} & {
+  type: 'location';
+  location: MessageCreateLocationV1;
+};
+
+export type MessageCreateLocationV1 = {
+  type: 'shared_coordinate';
+  shared_coordinate: {
+    coordinates: CoordinateV1;
+  };
+} & {
+  type: 'shared_place';
+  shared_place: {
+    place: { id: string };
+  };
+};
+
+// - Params -
+
+export interface SendDMV1Params extends MessageCreateDataV1 {
+  recipient_id: string;
+}
+
+export interface CreateDMEventV1Args {
+  event: CreateDMEventV1;
+}
+
+export interface CreateDMEventV1 {
+  type: EDirectMessageEventTypeV1;
+  [EDirectMessageEventTypeV1.Create]?: MessageCreateEventV1;
+}
+
+export interface GetDmListV1Args {
+  cursor?: string;
+  count?: number;
+}
+
+export interface CreateWelcomeDMEventV1Args {
+  [EDirectMessageEventTypeV1.WelcomeCreate]: {
+    name: string;
+    message_data: MessageCreateDataV1;
+  };
+}
+
+// - Responses -
+
+// Responses of DMs (payload replied by API)
+export interface DirectMessageCreateV1 extends RecievedDirectMessageEventV1 {
+  type: EDirectMessageEventTypeV1.Create;
+  [EDirectMessageEventTypeV1.Create]: ReceivedMessageCreateEventV1;
+}
+
+export interface RecievedDirectMessageEventV1 {
+  type: EDirectMessageEventTypeV1;
+  id: string;
+  created_timestamp: string;
+  initiated_via?: { tweet_id?: string, welcome_message_id?: string };
+}
+
+export interface ReceivedMessageCreateEventV1 {
+  target: { recipient_id: string };
+  sender_id: string;
+  source_app_id: string;
+  message_data: ReceivedMessageCreateDataV1;
+  custom_profile_id?: string;
+}
+
+export interface ReceivedMessageCreateDataV1 {
+  text: string;
+  entities: TweetEntitiesV1;
+  quick_reply_response?: { type: 'options', metadata?: string };
+  attachment?: MediaEntityV1;
+  quick_reply?: MessageCreateQuickReplyV1;
+  ctas?: MessageCreateCtaV1[];
+}
+// -- end dm event entity
+
+export interface ReceivedWelcomeDMCreateEventV1 {
+  id: string;
+  created_timestamp: string;
+  message_data: ReceivedMessageCreateDataV1;
+  name?: string;
+}
+
+export type DirectMessageCreateV1Result = { event: DirectMessageCreateV1 } & ReceivedDMAppsV1;
+
+export interface ReceivedDMAppsV1 {
+  apps?: ReceivedDMAppListV1;
+}
+
+// TODO add other events
+export type TReceivedDMEvent = DirectMessageCreateV1;
+
+// GET direct_messages/events/show
+export interface ReceivedDMEventV1 extends ReceivedDMAppsV1 {
+  event: TReceivedDMEvent;
+}
+
+// GET direct_messages/events/list
+export interface ReceivedDMEventsV1 extends ReceivedDMAppsV1 {
+  next_cursor?: string;
+  events: TReceivedDMEvent[];
+}
+
+export interface ReceivedDMAppListV1 {
+  [appId: string]: {
+    id: string;
+    name: string;
+    url: string;
+  };
+}
+
+// -- Welcome messages --
+
+// POST direct_messages/welcome_messages/new
+export interface WelcomeDirectMessageCreateV1Result extends ReceivedDMAppsV1 {
+  [EDirectMessageEventTypeV1.WelcomeCreate]: ReceivedWelcomeDMCreateEventV1;
+  name?: string;
+}
+
+// GET direct_messages/welcome_messages/list
+export interface WelcomeDirectMessageListV1Result extends ReceivedDMAppsV1 {
+  next_cursor?: string;
+  welcome_messages: ReceivedWelcomeDMCreateEventV1[];
+}
+
+// -- Welcome message rules --
+
+export interface CreateWelcomeDmRuleV1 {
+  welcome_message_id: string;
+}
+
+export interface WelcomeDmRuleV1 extends CreateWelcomeDmRuleV1 {
+  id: string;
+  created_timestamp: string;
+}
+
+export interface WelcomeDmRuleV1Result {
+  welcome_message_rule: WelcomeDmRuleV1;
+}
+
+export interface WelcomeDmRuleListV1Result {
+  next_cursor?: string;
+  welcome_message_rules: WelcomeDmRuleV1[];
+}
+
+// -- Custom profiles --
+
+export interface DmCustomProfileV1 {
+  name: string;
+  avatar: { media: MediaEntityV1 };
+}
+
+export interface ReceivedDmCustomProfileV1 extends DmCustomProfileV1 {
+  id: string;
+  created_timestamp: string;
+}
+
+export interface ReceivedDmCustomProfileItemV1 {
+  custom_profile: ReceivedDmCustomProfileV1;
+}
+
+export interface ReceivedDmCustomProfileListV1 {
+  next_cursor?: string;
+  custom_profiles: ReceivedDmCustomProfileV1[];
+}

--- a/src/types/v1/dm.v1.types.ts
+++ b/src/types/v1/dm.v1.types.ts
@@ -64,6 +64,7 @@ export type MessageCreateLocationV1 = {
 
 export interface SendDMV1Params extends MessageCreateDataV1 {
   recipient_id: string;
+  custom_profile_id?: string;
 }
 
 export interface CreateDMEventV1Args {
@@ -187,25 +188,4 @@ export interface WelcomeDmRuleV1Result {
 export interface WelcomeDmRuleListV1Result {
   next_cursor?: string;
   welcome_message_rules?: WelcomeDmRuleV1[];
-}
-
-// -- Custom profiles --
-
-export interface DmCustomProfileV1 {
-  name: string;
-  avatar: { media: MediaEntityV1 };
-}
-
-export interface ReceivedDmCustomProfileV1 extends DmCustomProfileV1 {
-  id: string;
-  created_timestamp: string;
-}
-
-export interface ReceivedDmCustomProfileItemV1 {
-  custom_profile: ReceivedDmCustomProfileV1;
-}
-
-export interface ReceivedDmCustomProfileListV1 {
-  next_cursor?: string;
-  custom_profiles: ReceivedDmCustomProfileV1[];
 }

--- a/src/types/v1/index.ts
+++ b/src/types/v1/index.ts
@@ -5,3 +5,4 @@ export * from './user.v1.types';
 export * from './dev-utilities.v1.types';
 export * from './geo.v1.types';
 export * from './trends.v1.types';
+export * from './dm.v1.types';

--- a/src/types/v1/tweet.v1.types.ts
+++ b/src/types/v1/tweet.v1.types.ts
@@ -90,6 +90,7 @@ export interface UploadMediaV1Params {
   additionalOwners: string;
   maxConcurrentUploads: number;
   target: 'tweet' | 'dm';
+  shared?: boolean;
 }
 
 export interface MediaMetadataV1Params {

--- a/src/v1/client.v1.ts
+++ b/src/v1/client.v1.ts
@@ -97,7 +97,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Creates a new Welcome Message that will be stored and sent in the future from the authenticating user in defined circumstances.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/new-welcome-message
    */
-  public newWelcomeMessage(name: string, data: MessageCreateDataV1) {
+  public newWelcomeDm(name: string, data: MessageCreateDataV1) {
     const args: CreateWelcomeDMEventV1Args = {
       [EDirectMessageEventTypeV1.WelcomeCreate]: {
         name,
@@ -114,7 +114,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Returns a Welcome Message by the given id.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/get-welcome-message
    */
-  public getWelcomeMessage(id: string) {
+  public getWelcomeDm(id: string) {
     return this.get<WelcomeDirectMessageCreateV1Result>('direct_messages/welcome_messages/show.json', { id });
   }
 
@@ -122,7 +122,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Deletes a Welcome Message by the given id.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/delete-welcome-message
    */
-  public deleteWelcomeMessage(id: string) {
+  public deleteWelcomeDm(id: string) {
     return this.delete<void>('direct_messages/welcome_messages/destroy.json', { id });
   }
 
@@ -131,7 +131,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Updates to the welcome_message object are atomic.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/update-welcome-message
    */
-  public updateWelcomeMessage(id: string, data: MessageCreateDataV1) {
+  public updateWelcomeDm(id: string, data: MessageCreateDataV1) {
     const args = { message_data: data };
     return this.put<WelcomeDirectMessageCreateV1Result>('direct_messages/welcome_messages/update.json', args, {
       forceBodyMode: 'json',
@@ -145,7 +145,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    *
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/list-events
    */
-  public async listWelcomeMessages(args: Partial<GetDmListV1Args> = {}) {
+  public async listWelcomeDms(args: Partial<GetDmListV1Args> = {}) {
     const queryParams = { ...args };
     const initialRq = await this.get<WelcomeDirectMessageListV1Result>('direct_messages/welcome_messages/list.json', queryParams, { fullResponse: true });
 
@@ -163,7 +163,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Creates a new Welcome Message Rule that determines which Welcome Message will be shown in a given conversation.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/new-welcome-message-rule
    */
-  public newWelcomeMessageRule(welcomeMessageId: string) {
+  public newWelcomeDmRule(welcomeMessageId: string) {
     return this.post<WelcomeDmRuleV1Result>('direct_messages/welcome_messages/rules/new.json', {
       welcome_message_rule: { welcome_message_id: welcomeMessageId },
     }, {
@@ -175,7 +175,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Returns a Welcome Message Rule by the given id.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/get-welcome-message-rule
    */
-  public getWelcomeMessageRule(id: string) {
+  public getWelcomeDmRule(id: string) {
     return this.get<WelcomeDmRuleV1Result>('direct_messages/welcome_messages/rules/show.json', { id });
   }
 
@@ -183,7 +183,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Deletes a Welcome Message Rule by the given id.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/delete-welcome-message-rule
    */
-  public deleteWelcomeMessageRule(id: string) {
+  public deleteWelcomeDmRule(id: string) {
     return this.delete<void>('direct_messages/welcome_messages/rules/destroy.json', { id });
   }
 
@@ -193,14 +193,14 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    *
    * If you don't have already a welcome message, create it with `.newWelcomeMessage`.
    */
-  public async setWelcomeMessage(welcomeMessageId: string) {
+  public async setWelcomeDm(welcomeMessageId: string) {
     const existingRules = await this.get<WelcomeDmRuleListV1Result>('direct_messages/welcome_messages/rules/list.json');
 
     if (existingRules.welcome_message_rules.length) {
-      await Promise.all(existingRules.welcome_message_rules.map(rule => this.deleteWelcomeMessageRule(rule.id)));
+      await Promise.all(existingRules.welcome_message_rules.map(rule => this.deleteWelcomeDmRule(rule.id)));
     }
 
-    return this.newWelcomeMessageRule(welcomeMessageId);
+    return this.newWelcomeDmRule(welcomeMessageId);
   }
 
   // Part: Custom profiles
@@ -261,7 +261,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Marks a message as read in the recipient’s Direct Message conversation view with the sender.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-read-receipt
    */
-  public markAsRead(lastEventId: string, recipientId: string) {
+  public markDmAsRead(lastEventId: string, recipientId: string) {
     return this.post<void>('direct_messages/mark_read.json', {
       last_read_event_id: lastEventId,
       recipient_id: recipientId,
@@ -272,7 +272,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Displays a visual typing indicator in the recipient’s Direct Message conversation view with the sender.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-typing-indicator
    */
-  public indicateTyping(recipientId: string) {
+  public indicateDmTyping(recipientId: string) {
     return this.post<void>('direct_messages/indicate_typing.json', {
       recipient_id: recipientId,
     }, { forceBodyMode: 'url' });

--- a/src/v1/client.v1.ts
+++ b/src/v1/client.v1.ts
@@ -254,6 +254,29 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
       queryParams,
     });
   }
+
+  // Part: Read indicator
+
+  /**
+   * Marks a message as read in the recipient’s Direct Message conversation view with the sender.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-read-receipt
+   */
+  public markAsRead(lastEventId: string, recipientId: string) {
+    return this.post<void>('direct_messages/mark_read.json', {
+      last_read_event_id: lastEventId,
+      recipient_id: recipientId,
+    }, { forceBodyMode: 'url' });
+  }
+
+  /**
+   * Displays a visual typing indicator in the recipient’s Direct Message conversation view with the sender.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-typing-indicator
+   */
+  public indicateTyping(recipientId: string) {
+    return this.post<void>('direct_messages/indicate_typing.json', {
+      recipient_id: recipientId,
+    }, { forceBodyMode: 'url' });
+  }
 }
 
 export default TwitterApiv1;

--- a/src/v1/client.v1.ts
+++ b/src/v1/client.v1.ts
@@ -204,13 +204,16 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    *
    * If you don't have already a welcome message, create it with `.newWelcomeMessage`.
    */
-  public async setWelcomeDm(welcomeMessageId: string) {
+  public async setWelcomeDm(welcomeMessageId: string, deleteAssociatedWelcomeDmWhenDeletingRule = true) {
     const existingRules = await this.listWelcomeDmRules();
 
     if (existingRules.welcome_message_rules?.length) {
       for (const rule of existingRules.welcome_message_rules) {
         await this.deleteWelcomeDmRule(rule.id);
-        await this.deleteWelcomeDm(rule.welcome_message_id);
+
+        if (deleteAssociatedWelcomeDmWhenDeletingRule) {
+          await this.deleteWelcomeDm(rule.welcome_message_id);
+        }
       }
     }
 

--- a/src/v1/client.v1.ts
+++ b/src/v1/client.v1.ts
@@ -1,4 +1,22 @@
 import { API_V1_1_PREFIX } from '../globals';
+import { CustomProfileDmV1Paginator, DmEventsV1Paginator, WelcomeDmV1Paginator } from '../paginators/dm.paginator.v1';
+import {
+  CreateDMEventV1Args,
+  EDirectMessageEventTypeV1,
+  SendDMV1Params,
+  DirectMessageCreateV1Result,
+  ReceivedDMEventV1,
+  ReceivedDMEventsV1,
+  GetDmListV1Args,
+  MessageCreateDataV1,
+  CreateWelcomeDMEventV1Args,
+  WelcomeDirectMessageCreateV1Result,
+  WelcomeDirectMessageListV1Result,
+  WelcomeDmRuleV1Result,
+  WelcomeDmRuleListV1Result,
+  ReceivedDmCustomProfileItemV1,
+  ReceivedDmCustomProfileListV1,
+} from '../types';
 import TwitterApiv1ReadWrite from './client.v1.write';
 
 /**
@@ -12,6 +30,229 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    */
   public get readWrite() {
     return this as TwitterApiv1ReadWrite;
+  }
+
+  /* Direct messages */
+  // Part: Sending and receiving events
+
+  /**
+   * Publishes a new message_create event resulting in a Direct Message sent to a specified user from the authenticating user.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/new-event
+   */
+  public sendDm({ recipient_id, ...params }: SendDMV1Params) {
+    const args: CreateDMEventV1Args = {
+      event: {
+        type: EDirectMessageEventTypeV1.Create,
+        [EDirectMessageEventTypeV1.Create]: {
+          target: { recipient_id },
+          message_data: params,
+        },
+      },
+    };
+
+    return this.post<DirectMessageCreateV1Result>('direct_messages/events/new.json', args, {
+      forceBodyMode: 'json',
+    });
+  }
+
+  /**
+   * Returns a single Direct Message event by the given id.
+   *
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/get-event
+   */
+  public getDmEvent(id: string) {
+    return this.get<ReceivedDMEventV1>('direct_messages/events/show.json', { id });
+  }
+
+  /**
+   * Deletes the direct message specified in the required ID parameter.
+   * The authenticating user must be the recipient of the specified direct message.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/delete-message-event
+   */
+  public deleteDm(id: string) {
+    return this.delete<void>('direct_messages/events/destroy.json', { id });
+  }
+
+  /**
+   * Returns all Direct Message events (both sent and received) within the last 30 days.
+   * Sorted in reverse-chronological order.
+   *
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/list-events
+   */
+  public async listDmEvents(args: Partial<GetDmListV1Args> = {}) {
+    const queryParams = { ...args };
+    const initialRq = await this.get<ReceivedDMEventsV1>('direct_messages/events/list.json', queryParams, { fullResponse: true });
+
+    return new DmEventsV1Paginator({
+      realData: initialRq.data,
+      rateLimit: initialRq.rateLimit!,
+      instance: this,
+      queryParams,
+    });
+  }
+
+  // Part: Welcome messages (events)
+
+  /**
+   * Creates a new Welcome Message that will be stored and sent in the future from the authenticating user in defined circumstances.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/new-welcome-message
+   */
+  public newWelcomeMessage(name: string, data: MessageCreateDataV1) {
+    const args: CreateWelcomeDMEventV1Args = {
+      [EDirectMessageEventTypeV1.WelcomeCreate]: {
+        name,
+        message_data: data,
+      },
+    };
+
+    return this.post<WelcomeDirectMessageCreateV1Result>('direct_messages/welcome_messages/new.json', args, {
+      forceBodyMode: 'json',
+    });
+  }
+
+  /**
+   * Returns a Welcome Message by the given id.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/get-welcome-message
+   */
+  public getWelcomeMessage(id: string) {
+    return this.get<WelcomeDirectMessageCreateV1Result>('direct_messages/welcome_messages/show.json', { id });
+  }
+
+  /**
+   * Deletes a Welcome Message by the given id.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/delete-welcome-message
+   */
+  public deleteWelcomeMessage(id: string) {
+    return this.delete<void>('direct_messages/welcome_messages/destroy.json', { id });
+  }
+
+  /**
+   * Updates a Welcome Message by the given ID.
+   * Updates to the welcome_message object are atomic.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/update-welcome-message
+   */
+  public updateWelcomeMessage(id: string, data: MessageCreateDataV1) {
+    const args = { message_data: data };
+    return this.put<WelcomeDirectMessageCreateV1Result>('direct_messages/welcome_messages/update.json', args, {
+      forceBodyMode: 'json',
+      query: { id },
+    });
+  }
+
+  /**
+   * Returns all Direct Message events (both sent and received) within the last 30 days.
+   * Sorted in reverse-chronological order.
+   *
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/list-events
+   */
+  public async listWelcomeMessages(args: Partial<GetDmListV1Args> = {}) {
+    const queryParams = { ...args };
+    const initialRq = await this.get<WelcomeDirectMessageListV1Result>('direct_messages/welcome_messages/list.json', queryParams, { fullResponse: true });
+
+    return new WelcomeDmV1Paginator({
+      realData: initialRq.data,
+      rateLimit: initialRq.rateLimit!,
+      instance: this,
+      queryParams,
+    });
+  }
+
+  // Part: Welcome message (rules)
+
+  /**
+   * Creates a new Welcome Message Rule that determines which Welcome Message will be shown in a given conversation.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/new-welcome-message-rule
+   */
+  public newWelcomeMessageRule(welcomeMessageId: string) {
+    return this.post<WelcomeDmRuleV1Result>('direct_messages/welcome_messages/rules/new.json', {
+      welcome_message_rule: { welcome_message_id: welcomeMessageId },
+    }, {
+      forceBodyMode: 'json', 
+    });
+  }
+
+  /**
+   * Returns a Welcome Message Rule by the given id.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/get-welcome-message-rule
+   */
+  public getWelcomeMessageRule(id: string) {
+    return this.get<WelcomeDmRuleV1Result>('direct_messages/welcome_messages/rules/show.json', { id });
+  }
+
+  /**
+   * Deletes a Welcome Message Rule by the given id.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/welcome-messages/api-reference/delete-welcome-message-rule
+   */
+  public deleteWelcomeMessageRule(id: string) {
+    return this.delete<void>('direct_messages/welcome_messages/rules/destroy.json', { id });
+  }
+
+  /**
+   * Set the current showed welcome message for logged account ; wrapper for Welcome DM rules.
+   * Test if a rule already exists, delete if any, then create a rule for current message ID.
+   *
+   * If you don't have already a welcome message, create it with `.newWelcomeMessage`.
+   */
+  public async setWelcomeMessage(welcomeMessageId: string) {
+    const existingRules = await this.get<WelcomeDmRuleListV1Result>('direct_messages/welcome_messages/rules/list.json');
+
+    if (existingRules.welcome_message_rules.length) {
+      await Promise.all(existingRules.welcome_message_rules.map(rule => this.deleteWelcomeMessageRule(rule.id)));
+    }
+
+    return this.newWelcomeMessageRule(welcomeMessageId);
+  }
+
+  // Part: Custom profiles
+
+  /**
+   * Creates a new custom profile.
+   * The returned ID should be used with when publishing a new message with POST direct_messages/events/new.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/custom-profiles/api-reference/new-profile
+   */
+  public newDmCustomProfile(name: string, avatarMediaId: string) {
+    return this.post<WelcomeDirectMessageCreateV1Result>('custom_profiles/new.json', {
+      custom_profile: {
+        name,
+        avatar: {
+          media: { id: avatarMediaId },
+        },
+      },
+    }, {
+      forceBodyMode: 'json',
+    });
+  }
+
+  /**
+   * Returns a custom profile that was created with POST custom_profiles/new.json.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/custom-profiles/api-reference/get-profile
+   */
+  public getDmCustomProfile(id: string) {
+    return this.get<ReceivedDmCustomProfileItemV1>(`custom_profiles/${id}.json`);
+  }
+
+  /**
+   * Deletes a custom profile that was created with POST custom_profiles/new.json.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/custom-profiles/api-reference/delete-profile
+   */
+  public deleteDmCustomProfile(id: string) {
+    return this.delete<void>('custom_profiles/destroy.json', { id });
+  }
+
+  /**
+   * Retrieves all custom profiles for the authenticated account.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/custom-profiles/api-reference/get-profile-list
+   */
+  public async listDmCustomProfiles(args: Partial<GetDmListV1Args> = {}) {
+    const queryParams = { ...args };
+    const initialRq = await this.get<ReceivedDmCustomProfileListV1>('custom_profiles/list.json', queryParams, { fullResponse: true });
+
+    return new CustomProfileDmV1Paginator({
+      realData: initialRq.data,
+      rateLimit: initialRq.rateLimit!,
+      instance: this,
+      queryParams,
+    });
   }
 }
 

--- a/src/v1/client.v1.write.ts
+++ b/src/v1/client.v1.write.ts
@@ -137,6 +137,7 @@ export default class TwitterApiv1ReadWrite extends TwitterApiv1ReadOnly {
           media_type: mimeType,
           media_category: mediaCategory,
           additional_owners: options.additionalOwners,
+          shared: options.shared ? true : undefined,
         },
         { prefix: API_V1_1_UPLOAD_PREFIX },
       );

--- a/test/dm.v1.test.ts
+++ b/test/dm.v1.test.ts
@@ -9,7 +9,6 @@ let client: TwitterApi;
 const TARGET_USER_ID = process.env.TARGET_DM_USER_ID as string;
 const TEST_UUID = Math.random();
 let isDmTestEnabled = false;
-const DISABLED_DM_SEND = true;
 
 if (process.env.TARGET_DM_USER_ID) {
   isDmTestEnabled = true;
@@ -21,7 +20,7 @@ describe('DM endpoints for v1.1 API', () => {
   });
 
   it('.sendDm/.getDmEvent/.deleteDm - Send a new direct message and fetch it.', async () => {
-    if (!isDmTestEnabled || DISABLED_DM_SEND) {
+    if (!isDmTestEnabled) {
       return;
     }
 
@@ -54,7 +53,7 @@ describe('DM endpoints for v1.1 API', () => {
   }).timeout(60 * 1000);
 
   it('.listDmEvents/.deleteDm - List DM events and delete every available DM sent to TARGET USER ID.', async () => {
-    if (!isDmTestEnabled || DISABLED_DM_SEND) {
+    if (!isDmTestEnabled) {
       return;
     }
 

--- a/test/dm.v1.test.ts
+++ b/test/dm.v1.test.ts
@@ -1,13 +1,15 @@
 import 'mocha';
 import { expect } from 'chai';
-import { EDirectMessageEventTypeV1, TwitterApi } from '../src';
+import { EDirectMessageEventTypeV1, ReceivedWelcomeDMCreateEventV1, TwitterApi, TwitterApiV2Settings } from '../src';
 import { getUserClient } from '../src/test/utils';
+import { sleepSecs } from '../src/v1/media-helpers.v1';
 
 let client: TwitterApi;
 
 const TARGET_USER_ID = process.env.TARGET_DM_USER_ID as string;
 const TEST_UUID = Math.random();
 let isDmTestEnabled = false;
+const DISABLED_DM_SEND = true;
 
 if (process.env.TARGET_DM_USER_ID) {
   isDmTestEnabled = true;
@@ -19,7 +21,7 @@ describe('DM endpoints for v1.1 API', () => {
   });
 
   it('.sendDm/.getDmEvent/.deleteDm - Send a new direct message and fetch it.', async () => {
-    if (!isDmTestEnabled) {
+    if (!isDmTestEnabled || DISABLED_DM_SEND) {
       return;
     }
 
@@ -52,7 +54,7 @@ describe('DM endpoints for v1.1 API', () => {
   }).timeout(60 * 1000);
 
   it('.listDmEvents/.deleteDm - List DM events and delete every available DM sent to TARGET USER ID.', async () => {
-    if (!isDmTestEnabled) {
+    if (!isDmTestEnabled || DISABLED_DM_SEND) {
       return;
     }
 
@@ -82,4 +84,89 @@ describe('DM endpoints for v1.1 API', () => {
       await v1Client.deleteDm(evt.id);
     }
   }).timeout(60 * 1000);
+
+  it('.newWelcomeDm/.getWelcomeDm/.updateWelcomeDm/.listWelcomeDms/.deleteWelcomeDm - Every method related to welcome messages.', async () => {
+    if (!isDmTestEnabled || DISABLED_DM_SEND) {
+      return;
+    }
+
+    const v1Client = client.v1;
+
+    // NEW WELCOME MESSAGE
+    const welcomeMsgUuid = 'WLC-MSG-NAME-' + Math.random().toString().slice(2, 10);
+    const newWelcomeMessage = await v1Client.newWelcomeDm(welcomeMsgUuid, {
+      text: 'New message text!',
+    });
+
+    const msgId = newWelcomeMessage[EDirectMessageEventTypeV1.WelcomeCreate].id;
+    expect(newWelcomeMessage).to.haveOwnProperty(EDirectMessageEventTypeV1.WelcomeCreate);
+    expect(newWelcomeMessage[EDirectMessageEventTypeV1.WelcomeCreate].message_data.text).to.equal('New message text!');
+    expect(newWelcomeMessage[EDirectMessageEventTypeV1.WelcomeCreate].name).to.equal(welcomeMsgUuid);
+
+    // GET WELCOME MESSAGE
+    const existingWelcomeMessage = await v1Client.getWelcomeDm(msgId);
+    expect(existingWelcomeMessage).to.haveOwnProperty(EDirectMessageEventTypeV1.WelcomeCreate);
+    expect(existingWelcomeMessage[EDirectMessageEventTypeV1.WelcomeCreate].message_data.text).to.equal('New message text!');
+    expect(existingWelcomeMessage[EDirectMessageEventTypeV1.WelcomeCreate].name).to.equal(welcomeMsgUuid);
+
+    // UPDATE WELCOME MESSAGE
+    const updatedMessage = await v1Client.updateWelcomeDm(msgId, { text: 'Updated message text!' });
+    expect(updatedMessage[EDirectMessageEventTypeV1.WelcomeCreate].message_data.text).to.equal('Updated message text!');
+
+    // LIST WELCOME MESSAGE (and ensure our sent DM is inside the list.)
+    const welcomeMsgPaginator = await v1Client.listWelcomeDms();
+    const allWelcomeDirectMessages = [] as ReceivedWelcomeDMCreateEventV1[];
+
+    for await (const dm of welcomeMsgPaginator) {
+      allWelcomeDirectMessages.push(dm);
+    }
+
+    expect(allWelcomeDirectMessages.some(msg => msg.id === msgId)).to.be.true;
+
+    // Delete the welcome DM
+    await v1Client.deleteWelcomeDm(msgId);
+  }).timeout(120 * 1000);
+
+  it('.newWelcomeDmRule/.getWelcomeDmRule/.listWelcomeDmRules/.deleteWelcomeDmRule/.setWelcomeDm - Every method related to welcome messages rules.', async () => {
+    if (!isDmTestEnabled) {
+      return;
+    }
+
+    const v1Client = client.v1;
+    const currentRules = await v1Client.listWelcomeDmRules();
+    // Cleanup every available dm rule
+    for await (const rule of currentRules.welcome_message_rules ?? []) {
+      await v1Client.deleteWelcomeDmRule(rule.id);
+    }
+
+    // NEW WELCOME MESSAGE
+    const welcomeMsgUuid = 'WLC-MSG-NAME-' + Math.random().toString().slice(2, 10);
+    const newWelcomeMessage = await v1Client.newWelcomeDm(welcomeMsgUuid, {
+      text: 'New message text, for rule!',
+    });
+
+    const msgId = newWelcomeMessage[EDirectMessageEventTypeV1.WelcomeCreate].id;
+
+    // Create the rule
+    const rule = await v1Client.newWelcomeDmRule(msgId);
+    expect(rule.welcome_message_rule.welcome_message_id).to.equal(msgId);
+
+    await sleepSecs(4);
+
+    // Create another welcome message
+    const welcomeMsgUuid2 = 'WLC-MSG-NAME-' + Math.random().toString().slice(2, 10);
+    const anotherWelcomeMessage = await v1Client.newWelcomeDm(welcomeMsgUuid2, {
+      text: 'New message text, for rule (2)!',
+    });
+
+    const newMsgId = anotherWelcomeMessage[EDirectMessageEventTypeV1.WelcomeCreate].id;
+
+    // Set another rule (will list and delete older rules)
+    const newRule = await v1Client.setWelcomeDm(newMsgId);
+
+    // Other rule should be deleted.
+    // Delete new rule
+    await v1Client.deleteWelcomeDmRule(newRule.welcome_message_rule.id);
+    await v1Client.deleteWelcomeDm(newRule.welcome_message_rule.welcome_message_id);
+  }).timeout(120 * 1000);
 });

--- a/test/dm.v1.test.ts
+++ b/test/dm.v1.test.ts
@@ -1,0 +1,85 @@
+import 'mocha';
+import { expect } from 'chai';
+import { EDirectMessageEventTypeV1, TwitterApi } from '../src';
+import { getUserClient } from '../src/test/utils';
+
+let client: TwitterApi;
+
+const TARGET_USER_ID = process.env.TARGET_DM_USER_ID as string;
+const TEST_UUID = Math.random();
+let isDmTestEnabled = false;
+
+if (process.env.TARGET_DM_USER_ID) {
+  isDmTestEnabled = true;
+}
+
+describe('DM endpoints for v1.1 API', () => {
+  before(() => {
+    client = getUserClient();
+  });
+
+  it('.sendDm/.getDmEvent/.deleteDm - Send a new direct message and fetch it.', async () => {
+    if (!isDmTestEnabled) {
+      return;
+    }
+
+    const v1Client = client.v1;
+    const selfAccount = await client.currentUser();
+    const msgText = `Hello, this is a new direct message from an automated script - UUID: ${TEST_UUID}`;
+
+    const sentMessage = await v1Client.sendDm({
+      recipient_id: TARGET_USER_ID,
+      text: msgText,
+    });
+
+    expect(sentMessage.event.type).to.equal(EDirectMessageEventTypeV1.Create);
+
+    // Get event to repeat action
+    const messageEvent = await v1Client.getDmEvent(sentMessage.event.id);
+
+    for (const evt of [sentMessage.event, messageEvent.event]) {
+      const msgCreate = evt[EDirectMessageEventTypeV1.Create];
+      expect(msgCreate).to.be.ok;
+      expect(msgCreate).to.haveOwnProperty('message_data');
+      expect(msgCreate.message_data.text).to.equal(msgText);
+      expect(msgCreate.message_data.quick_reply).to.be.undefined;
+      expect(msgCreate.message_data.quick_reply_response).to.be.undefined;
+      expect(msgCreate.message_data.attachment).to.be.undefined;
+      expect(msgCreate.message_data.ctas).to.be.undefined;
+      expect(msgCreate.target.recipient_id).to.equal(TARGET_USER_ID);
+      expect(msgCreate.sender_id).to.equal(selfAccount.id_str);
+    }
+  }).timeout(60 * 1000);
+
+  it('.listDmEvents/.deleteDm - List DM events and delete every available DM sent to TARGET USER ID.', async () => {
+    if (!isDmTestEnabled) {
+      return;
+    }
+
+    const v1Client = client.v1;
+    const selfAccount = await client.currentUser();
+
+    const eventPaginator = await v1Client.listDmEvents();
+
+    for await (const evt of eventPaginator) {
+      expect(evt.type).to.equal(EDirectMessageEventTypeV1.Create);
+
+      const msgCreate = evt[EDirectMessageEventTypeV1.Create];
+      expect(msgCreate).to.be.ok;
+
+      if (msgCreate.target.recipient_id !== TARGET_USER_ID) {
+        continue;
+      }
+
+      expect(msgCreate).to.haveOwnProperty('message_data');
+      expect(msgCreate.message_data.quick_reply).to.be.undefined;
+      expect(msgCreate.message_data.quick_reply_response).to.be.undefined;
+      expect(msgCreate.message_data.attachment).to.be.undefined;
+      expect(msgCreate.message_data.ctas).to.be.undefined;
+      expect(msgCreate.target.recipient_id).to.equal(TARGET_USER_ID);
+      expect(msgCreate.sender_id).to.equal(selfAccount.id_str);
+
+      await v1Client.deleteDm(evt.id);
+    }
+  }).timeout(60 * 1000);
+});

--- a/test/dm.v1.test.ts
+++ b/test/dm.v1.test.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { expect } from 'chai';
-import { EDirectMessageEventTypeV1, ReceivedWelcomeDMCreateEventV1, TwitterApi, TwitterApiV2Settings } from '../src';
+import { EDirectMessageEventTypeV1, ReceivedWelcomeDMCreateEventV1, TwitterApi } from '../src';
 import { getUserClient } from '../src/test/utils';
 import { sleepSecs } from '../src/v1/media-helpers.v1';
 
@@ -86,7 +86,7 @@ describe('DM endpoints for v1.1 API', () => {
   }).timeout(60 * 1000);
 
   it('.newWelcomeDm/.getWelcomeDm/.updateWelcomeDm/.listWelcomeDms/.deleteWelcomeDm - Every method related to welcome messages.', async () => {
-    if (!isDmTestEnabled || DISABLED_DM_SEND) {
+    if (!isDmTestEnabled) {
       return;
     }
 


### PR DESCRIPTION
Provide wrappers and paginators to nearly every public DM endpoints (in 1.1 API):
- Send, get, list and delete DM events
- Send, get, list, update and delete welcome DMs
- Create, get, list and delete welcome DM rules (+ helper to combine list+delete+create)
- Mark a DM as read
- Indicate typing in a DM 1-to-1 conversation

With appropriate documentation + test suite :)

*Note*: Test suite is disabled by default, as it requires a user-defined sender ID and an application that supports direct messages auth level. To enable test suite, define env variable `TARGET_DM_USER_ID`.