### PR TITLE
Fix endpoint body auto-detection

### DIFF
--- a/src/client-mixins/request-maker.mixin.ts
+++ b/src/client-mixins/request-maker.mixin.ts
@@ -232,8 +232,10 @@ class RequestParamHelpers {
     }
 
     if (requestUrl.hostname === 'upload.twitter.com') {
-      // json except for APPEND command, that is form-data.
-      // this should be explicitely set.
+      if (requestUrl.pathname === '/1.1/media/upload.json') {
+        return 'form-data';
+      }
+      // json except for media/upload command, that is form-data.
       return 'json';
     }
 

--- a/src/v1/client.v1.write.ts
+++ b/src/v1/client.v1.write.ts
@@ -277,7 +277,7 @@ export default class TwitterApiv1ReadWrite extends TwitterApiv1ReadOnly {
             segment_index: chunkIndex,
             media: mediaBufferPart,
           },
-          { prefix: API_V1_1_UPLOAD_PREFIX, forceBodyMode: 'form-data' },
+          { prefix: API_V1_1_UPLOAD_PREFIX },
         );
 
         currentUploads.add(request);

--- a/src/v1/client.v1.write.ts
+++ b/src/v1/client.v1.write.ts
@@ -277,7 +277,7 @@ export default class TwitterApiv1ReadWrite extends TwitterApiv1ReadOnly {
             segment_index: chunkIndex,
             media: mediaBufferPart,
           },
-          { prefix: API_V1_1_UPLOAD_PREFIX },
+          { prefix: API_V1_1_UPLOAD_PREFIX, forceBodyMode: 'form-data' },
         );
 
         currentUploads.add(request);


### PR DESCRIPTION
- JSON 1.1 endpoints are not properly detected (missing .json in list)
- Some upload.twitter.com endpoints are badly auto-detected
- Labs v2 unsupported

This MR fix it all.