### PR TITLE
chore: set allowSyntheticDefaultImport to false to improve compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "twitter-api-v2",
       "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/src/client-mixins/oauth1.helper.ts
+++ b/src/client-mixins/oauth1.helper.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 
 // ----------------------------------------------------------
 // LICENSE: This code partially belongs to oauth-1.0a package

--- a/src/stream/TweetStreamEventCombiner.ts
+++ b/src/stream/TweetStreamEventCombiner.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import { ETwitterStreamEvent } from '../types';
 import type TweetStream from './TweetStream';
 

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,5 +1,5 @@
 import { TwitterApi } from '..';
-import dotenv from 'dotenv';
+import * as dotenv from 'dotenv';
 
 dotenv.config({ path: __dirname + '/../../.env' });
 

--- a/src/types/v1/tweet.v1.types.ts
+++ b/src/types/v1/tweet.v1.types.ts
@@ -1,5 +1,5 @@
 import type { BooleanString, NumberString } from '../shared.types';
-import type fs from 'fs';
+import type * as fs from 'fs';
 import { UserV1 } from './user.v1.types';
 import { CoordinateV1, PlaceV1, TweetEntitiesV1, TweetExtendedEntitiesV1 } from './entities.v1.types';
 

--- a/src/v1/client.v1.write.ts
+++ b/src/v1/client.v1.write.ts
@@ -10,7 +10,7 @@ import {
   TweetV1,
   UploadMediaV1Params,
 } from '../types';
-import fs from 'fs';
+import * as fs from 'fs';
 import { getFileHandle, getFileSizeFromFileHandle, getMediaCategoryByMime, getMimeType, readNextPartOf, sleepSecs, TFileHandle } from './media-helpers.v1';
 
 const UPLOAD_ENDPOINT = 'media/upload.json';

--- a/src/v1/media-helpers.v1.ts
+++ b/src/v1/media-helpers.v1.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import * as fs from 'fs';
 import type { TUploadableMedia, TUploadTypeV1 } from '../types';
 
 // -------------

--- a/test/media-upload.test.ts
+++ b/test/media-upload.test.ts
@@ -2,8 +2,8 @@ import 'mocha';
 import { expect } from 'chai';
 import { TwitterApi } from '../src';
 import { getUserClient } from '../src/test/utils';
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 
 let client: TwitterApi;
 const dirname = __dirname;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "allowSyntheticDefaultImports": false,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */


### PR DESCRIPTION
Fixes https://github.com/PLhery/node-twitter-api-v2/issues/56

If we don't explicitely write `import * as fs from 'fs'` instead of  `import fs from 'fs'`, our typescript definition files won't have this form neither.

Because some projects may have allowSyntheticDefaultImport=false, let's set it to false to improve compatibility