### PR TITLE
Added non_public_metrics, promoted_metrics and organic_metrics to tweet.fields

### DIFF
--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -45,7 +45,8 @@ export type TTweetv2MediaField = 'duration_ms' | 'height' | 'media_key' | 'previ
 export type TTweetv2PlaceField = 'contained_within' | 'country' | 'country_code' | 'full_name' | 'geo' | 'id' | 'name' | 'place_type';
 export type TTweetv2PollField = 'duration_minutes' | 'end_datetime' | 'id' | 'options' | 'voting_status';
 export type TTweetv2TweetField = 'attachments' | 'author_id' | 'context_annotations' | 'conversation_id'
-  | 'created_at' | 'entities' | 'geo' | 'id' | 'in_reply_to_user_id' | 'lang' | 'public_metrics'
+  | 'created_at' | 'entities' | 'geo' | 'id' | 'in_reply_to_user_id' | 'lang' 
+  | 'public_metrics' | 'non_public_metrics' | 'promoted_metrics' | 'organic_metrics'
   | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld';
 export type TTweetv2UserField = 'created_at' | 'description' | 'entities' | 'id' | 'location'
   | 'name' | 'pinned_tweet_id' | 'profile_image_url' | 'protected' | 'public_metrics'


### PR DESCRIPTION
via issue #58 
Added missing `non_public_metrics`, `promoted_metrics` and `organic_metrics` fields to `tweet.fields`