### PR TITLE
Include endpoint wrappers & types for Spaces API

### DIFF
--- a/doc/v2.md
+++ b/doc/v2.md
@@ -629,6 +629,96 @@ await client.v2.mute('12', '1903892');
 await client.v2.unmute('12', '1903892');
 ```
 
+## Spaces
+
+### Space by ID
+
+Get a single space by its ID.
+
+**Method**: `.space()`
+
+**Endpoint**: `spaces/:id`
+
+**Right level**: `Read-only`
+
+**Arguments**:
+  - `spaceId: string`
+  - `options?: SpaceV2FieldsParams`
+
+**Returns**: `SpaceV2SingleResult`
+
+**Example**
+```ts
+const { data: space } = await client.v2.space('space-id')
+// space is a SpaceV2
+console.log(space.state) // 'live'
+```
+
+### Spaces by ID
+
+Get spaces by its ID.
+
+**Method**: `.spaces()`
+
+**Endpoint**: `spaces`
+
+**Right level**: `Read-only`
+
+**Arguments**:
+  - `spaceIds: string | string[]`
+  - `options?: SpaceV2FieldsParams`
+
+**Returns**: `SpaceV2LookupResult`
+
+**Example**
+```ts
+const { data: spaces } = await client.v2.spaces('space-id,space-2-id')
+console.log(spaces) // SpaceV2[]
+```
+
+### Spaces by their creator ID
+
+Get spaces users who created them. (No pagination available)
+
+**Method**: `.spacesByCreators()`
+
+**Endpoint**: `spaces/by/creator_ids`
+
+**Right level**: `Read-only`
+
+**Arguments**:
+  - `creatorUserIds: string | string[]`
+  - `options?: SpaceV2FieldsParams`
+
+**Returns**: `SpaceV2LookupResult`
+
+**Example**
+```ts
+const { data: spaces } = await client.v2.spacesByCreators(['12', '1024'])
+console.log(spaces) // SpaceV2[] - Spaces of users '12' and '1024'
+```
+
+### Search spaces
+
+Search spaces using a query (will be looked up in their title) and their state. (No pagination available)
+
+**Method**: `.searchSpaces()`
+
+**Endpoint**: `spaces/search`
+
+**Right level**: `Read-only`
+
+**Arguments**:
+  - `options: SpaceV2SearchParams`
+
+**Returns**: `SpaceV2LookupResult`
+
+**Example**
+```ts
+const { data: spaces } = await client.v2.searchSpaces({ query: 'Node JS', state: 'live' })
+console.log(spaces) // SpaceV2[] - Found live spaces talking about NodeJS!
+```
+
 <!--
 ## API type
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test-media": "npm run mocha test/media-upload.test.ts",
     "test-auth": "npm run mocha test/auth.test.ts",
     "test-dm": "npm run mocha test/dm.*.test.ts",
+    "test-space": "npm run mocha test/space.v2.test.ts",
     "prepublish": "npm run build"
   },
   "repository": "github:plhery/node-twitter-api-v2",

--- a/src/types/v2/index.ts
+++ b/src/types/v2/index.ts
@@ -2,3 +2,4 @@ export * from './streaming.v2.types';
 export * from './tweet.v2.types';
 export * from './tweet.definition.v2';
 export * from './user.v2.types';
+export * from './spaces.v2.types';

--- a/src/types/v2/spaces.v2.types.ts
+++ b/src/types/v2/spaces.v2.types.ts
@@ -1,0 +1,53 @@
+import { TypeOrArrayOf } from "../shared.types";
+import { DataAndIncludeV2, DataV2 } from "./shared.v2.types";
+import { TTweetv2UserField } from "./tweet.v2.types";
+import { UserV2 } from "./user.v2.types";
+
+export interface SpaceV2FieldsParams {
+  expansions: TypeOrArrayOf<TSpaceV2Expansion> | string;
+  'space.fields': TypeOrArrayOf<TSpaceV2SpaceField> | string;
+  'user.fields': TypeOrArrayOf<TTweetv2UserField> | string;
+}
+
+export type TSpaceV2Expansion = 'invited_user_ids' | 'speaker_ids' | 'creator_id' | 'host_ids';
+export type TSpaceV2SpaceField = 'host_ids' | 'created_at' | 'creator_id' | 'id' | 'lang'
+  | 'invited_user_ids' | 'participant_count' | 'speaker_ids' | 'started_at' | 'state' | 'title'
+  | 'updated_at' | 'scheduled_start' | 'is_ticketed';
+export type TSpaceV2State = 'live' | 'scheduled';
+
+// - Requests -
+
+export interface SpaceV2CreatorLookupParams extends SpaceV2FieldsParams {
+  max_results?: number;
+}
+
+export interface SpaceV2SearchParams extends Partial<SpaceV2FieldsParams> {
+  query: string;
+  state: TSpaceV2State;
+  max_results?: number;
+}
+
+// - Responses -
+
+type SpaceV2Includes = { users?: UserV2[] };
+
+export type SpaceV2SingleResult = DataV2<SpaceV2>;
+export type SpaceV2LookupResult = DataAndIncludeV2<SpaceV2[], SpaceV2Includes>;
+
+// - Entities -
+
+export interface SpaceV2 {
+  id: string;
+  state: TSpaceV2State;
+  created_at: string;
+  host_ids: string[];
+  lang: string;
+  is_ticketed: boolean;
+  invited_user_ids: string[];
+  participant_count: number;
+  scheduled_start: string;
+  speaker_ids: string[];
+  started_at: string;
+  title: string;
+  updated_at: string;
+}

--- a/src/types/v2/spaces.v2.types.ts
+++ b/src/types/v2/spaces.v2.types.ts
@@ -1,5 +1,5 @@
 import type { TypeOrArrayOf } from '../shared.types';
-import type { DataAndIncludeV2, DataV2 } from './shared.v2.types';
+import type { DataMetaAndIncludeV2, DataV2 } from './shared.v2.types';
 import type { TTweetv2UserField } from './tweet.v2.types';
 import type { UserV2 } from './user.v2.types';
 
@@ -32,7 +32,7 @@ export interface SpaceV2SearchParams extends Partial<SpaceV2FieldsParams> {
 type SpaceV2Includes = { users?: UserV2[] };
 
 export type SpaceV2SingleResult = DataV2<SpaceV2>;
-export type SpaceV2LookupResult = DataAndIncludeV2<SpaceV2[], SpaceV2Includes>;
+export type SpaceV2LookupResult = DataMetaAndIncludeV2<SpaceV2[], { result_count: number }, SpaceV2Includes>;
 
 // - Entities -
 

--- a/src/types/v2/spaces.v2.types.ts
+++ b/src/types/v2/spaces.v2.types.ts
@@ -1,7 +1,7 @@
-import { TypeOrArrayOf } from "../shared.types";
-import { DataAndIncludeV2, DataV2 } from "./shared.v2.types";
-import { TTweetv2UserField } from "./tweet.v2.types";
-import { UserV2 } from "./user.v2.types";
+import type { TypeOrArrayOf } from '../shared.types';
+import type { DataAndIncludeV2, DataV2 } from './shared.v2.types';
+import type { TTweetv2UserField } from './tweet.v2.types';
+import type { UserV2 } from './user.v2.types';
 
 export interface SpaceV2FieldsParams {
   expansions: TypeOrArrayOf<TSpaceV2Expansion> | string;

--- a/src/types/v2/spaces.v2.types.ts
+++ b/src/types/v2/spaces.v2.types.ts
@@ -39,15 +39,16 @@ export type SpaceV2LookupResult = DataAndIncludeV2<SpaceV2[], SpaceV2Includes>;
 export interface SpaceV2 {
   id: string;
   state: TSpaceV2State;
-  created_at: string;
-  host_ids: string[];
-  lang: string;
-  is_ticketed: boolean;
-  invited_user_ids: string[];
-  participant_count: number;
-  scheduled_start: string;
-  speaker_ids: string[];
-  started_at: string;
-  title: string;
-  updated_at: string;
+  created_at?: string;
+  host_ids?: string[];
+  lang?: string;
+  is_ticketed?: boolean;
+  invited_user_ids?: string[];
+  participant_count?: number;
+  scheduled_start?: string;
+  speaker_ids?: string[];
+  started_at?: string;
+  title?: string;
+  creator_id?: string;
+  updated_at?: string;
 }

--- a/src/v2/client.v2.read.ts
+++ b/src/v2/client.v2.read.ts
@@ -31,6 +31,11 @@ import {
   TweetV2SingleStreamResult,
   TweetV2PaginableListParams,
   Tweetv2ListResult,
+  SpaceV2FieldsParams,
+  SpaceV2LookupResult,
+  SpaceV2CreatorLookupParams,
+  SpaceV2SearchParams,
+  SpaceV2SingleResult,
 } from '../types';
 import {
   TweetSearchAllV2Paginator,
@@ -301,6 +306,40 @@ export default class TwitterApiv2ReadOnly extends TwitterApiSubClient {
       queryParams: { ...options },
       sharedParams: { userId },
     });
+  }
+
+  /* Spaces */
+
+  /**
+   * Get a single space by ID.
+   * https://developer.twitter.com/en/docs/twitter-api/spaces/lookup/api-reference/get-spaces-id
+   */
+  public space(spaceId: string, options: Partial<SpaceV2FieldsParams> = {}) {
+    return this.get<SpaceV2SingleResult>(`spaces/${spaceId}`, options);
+  }
+
+  /**
+   * Get spaces using their IDs.
+   * https://developer.twitter.com/en/docs/twitter-api/spaces/lookup/api-reference/get-spaces
+   */
+  public spaces(spaceIds: string | string[], options: Partial<SpaceV2FieldsParams> = {}) {
+    return this.get<SpaceV2LookupResult>('spaces', { ids: spaceIds, ...options });
+  }
+
+  /**
+   * Get spaces using their creator user ID(s). (no pagination available)
+   * https://developer.twitter.com/en/docs/twitter-api/spaces/lookup/api-reference/get-spaces-by-creator-ids
+   */
+  public spacesByCreators(creatorIds: string | string[], options: Partial<SpaceV2CreatorLookupParams> = {}) {
+    return this.get<SpaceV2LookupResult>('spaces/by/creator_ids', { user_ids: creatorIds, ...options });
+  }
+
+  /**
+   * Search through spaces using multiple params. (no pagination available)
+   * https://developer.twitter.com/en/docs/twitter-api/spaces/search/api-reference/get-spaces-search
+   */
+  public searchSpaces(options: SpaceV2SearchParams) {
+    return this.get<SpaceV2LookupResult>('spaces/search', options as Partial<SpaceV2SearchParams>);
   }
 
   /* Streaming API */

--- a/test/space.v2.test.ts
+++ b/test/space.v2.test.ts
@@ -1,0 +1,38 @@
+import 'mocha';
+import { expect } from 'chai';
+import { TwitterApi } from '../src';
+import { getAppClient } from '../src/test/utils';
+
+let client: TwitterApi;
+
+describe('Spaces endpoints for v2 API', () => {
+  before(async () => {
+    client = await getAppClient();
+  });
+
+  it('.space/.spaces/.searchSpaces/.spacesByCreators - Lookup for spaces', async () => {
+    const spacesBySearch = await client.v2.searchSpaces({
+      query: 'twitter',
+      state: 'live',
+      'space.fields': ['created_at', 'host_ids', 'title', 'lang', 'invited_user_ids', 'creator_id'],
+    });
+
+    expect(spacesBySearch.meta).to.be.a('object');
+    expect(spacesBySearch.meta.result_count).to.be.a('number');
+
+    if (spacesBySearch.data?.length) {
+      const space = spacesBySearch.data[0];
+      expect(space.created_at).to.be.a('string');
+      expect(space.creator_id).to.be.a('string');
+      expect(space.host_ids).to.be.a('array');
+
+      const singleSpace = await client.v2.space(space.id);
+      const singleSpaceThroughLookup = await client.v2.spaces([space.id]);
+      const spacesOfCreator = await client.v2.spacesByCreators([space.creator_id!])
+
+      expect(singleSpace.data.id).to.equal(space.id);
+      expect(singleSpaceThroughLookup.data[0].id).to.equal(space.id);
+      expect(spacesOfCreator.data.some(s => s.id === space.id)).to.equal(true);
+    }
+  }).timeout(60 * 1000);
+});


### PR DESCRIPTION
#55 Include typings for brand new Spaces API (see https://developer.twitter.com/en/docs/twitter-api/spaces/overview).

- `.space`: Get a single space by ID
- `.spaces`: Lookup for spaces by IDs
- `.spacesByCreators`: Lookup for spaces by creator user IDs
- `.searchSpaces`: Lookup for spaces using a query on their title / state

Doc ok + unit test ok + typings ok.