### PR TITLE
fix: Fix incorrect max results in paginators

### DIFF
--- a/src/paginators/TwitterPaginator.ts
+++ b/src/paginators/TwitterPaginator.ts
@@ -108,7 +108,7 @@ export abstract class TwitterPaginator<TApiResult, TApiParams extends object, TI
    * Fetch up to {count} items after current page,
    * as long as rate limit is not hit and Twitter has some results
    */
-  async fetchLast(count: number) {
+  async fetchLast(count = Infinity) {
     let queryParams = this.getNextQueryParams(this._maxResultsWhenFetchLast);
 
     let resultCount = 0;

--- a/src/paginators/TwitterPaginator.ts
+++ b/src/paginators/TwitterPaginator.ts
@@ -59,6 +59,13 @@ export abstract class TwitterPaginator<TApiResult, TApiParams extends object, TI
     return this._endpoint;
   }
 
+  protected injectQueryParams(maxResults?: number) {
+    return {
+      ...(maxResults ? { max_results: maxResults } : {}),
+      ...this._queryParams,
+    };
+  }
+
   protected abstract refreshInstanceFromResult(result: TwitterResponse<TApiResult>, isNextPage: boolean): any;
 
   protected abstract getNextQueryParams(maxResults?: number): Partial<TApiParams>;

--- a/src/paginators/tweet.paginator.v1.ts
+++ b/src/paginators/tweet.paginator.v1.ts
@@ -27,9 +27,8 @@ abstract class TweetTimelineV1Paginator<
     const lastestId = BigInt(this._realData[this._realData.length - 1].id_str);
 
     return {
-      ...this._queryParams,
+      ...this.injectQueryParams(maxResults),
       max_id: (lastestId - BigInt(1)).toString(),
-      ...maxResults ? { max_results: maxResults } : {},
     };
   }
 

--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -102,17 +102,15 @@ abstract class TweetTimelineV2Paginator<
 
   protected getNextQueryParams(maxResults?: number) {
     return {
-      ...this._queryParams,
+      ...this.injectQueryParams(maxResults),
       until_id: this._realData.meta.oldest_id,
-      ...(maxResults ? { max_results: maxResults } : {}),
     };
   }
 
   protected getPreviousQueryParams(maxResults?: number) {
     return {
-      ...this._queryParams,
+      ...this.injectQueryParams(maxResults),
       since_id: this._realData.meta.newest_id,
-      ...(maxResults ? { max_results: maxResults } : {}),
     };
   }
 }
@@ -190,17 +188,15 @@ abstract class TweetListV2Paginator<
 
   protected getNextQueryParams(maxResults?: number) {
     return {
-      ...this._queryParams,
+      ...this.injectQueryParams(maxResults),
       pagination_token: this._realData.meta.next_token,
-      ...(maxResults ? { max_results: maxResults } : {}),
     };
   }
 
   protected getPreviousQueryParams(maxResults?: number) {
     return {
-      ...this._queryParams,
+      ...this.injectQueryParams(maxResults),
       pagination_token: this._realData.meta.previous_token,
-      ...(maxResults ? { max_results: maxResults } : {}),
     };
   }
 }

--- a/src/paginators/user.paginator.v2.ts
+++ b/src/paginators/user.paginator.v2.ts
@@ -54,17 +54,15 @@ abstract class UserTimelineV2Paginator<
 
   protected getNextQueryParams(maxResults?: number) {
     return {
-      ...this._queryParams,
+      ...this.injectQueryParams(maxResults),
       pagination_token: this._realData.meta.next_token,
-      ...(maxResults ? { max_results: maxResults } : {}),
     };
   }
 
   protected getPreviousQueryParams(maxResults?: number) {
     return {
-      ...this._queryParams,
+      ...this.injectQueryParams(maxResults),
       pagination_token: this._realData.meta.previous_token,
-      ...(maxResults ? { max_results: maxResults } : {}),
     };
   }
 


### PR DESCRIPTION
Fix incorrect max results in paginators when max results is explicit in query params.
+ Set default parameter value `count` to `Infinity` for `.fetchLast` method in paginators.

Addresses #74.