### PR TITLE
Try to fix stream reconnection errors

### DIFF
--- a/src/client-mixins/request-maker.mixin.ts
+++ b/src/client-mixins/request-maker.mixin.ts
@@ -38,6 +38,7 @@ export interface IGetHttpRequestArgs {
   forceBodyMode?: TBodyMode;
   enableAuth?: boolean;
   enableRateLimitSave?: boolean;
+  timeout?: number;
 }
 
 export interface IGetStreamRequestArgs {
@@ -77,7 +78,7 @@ export abstract class ClientRequestMaker {
   /** Send a new request and returns a wrapped `Promise<TwitterResponse<T>`. */
   send<T = any>(requestParams: IGetHttpRequestArgs) : Promise<TwitterResponse<T>> {
     const args = this.getHttpRequestArgs(requestParams);
-    const options = { method: args.method, headers: args.headers };
+    const options = { method: args.method, headers: args.headers, timeout: requestParams.timeout };
     const enableRateLimitSave = requestParams.enableRateLimitSave !== false;
 
     if (args.body) {


### PR DESCRIPTION
Try to fix stream reconnection errors by always force-closing requests and locking reconnection process.

This is a pure hotfix, that don't break anything, but I'm not sure this will work.
It could fix #92.