### PR TITLE
feat: add v2 post single tweet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "twitter-api-v2",
-  "version": "1.3.0",
+  "version": "1.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.3.0",
+      "name": "twitter-api-v2",
+      "version": "1.6.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/chai": "^4.2.16",

--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -173,7 +173,7 @@ export interface SendTweetV2Params {
     exclude_reply_user_ids?: string[];
     in_reply_to_tweet_id: string[];
   };
-  reply_settings?: "mentionedUsers" | "following" | "everyone"
+  reply_settings?: 'mentionedUsers' | 'following' | 'everyone'
 }
 
 //// FINALLY, TweetV2

--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -154,6 +154,28 @@ export interface TweetOrganicMetricsV2 {
 
 export type TweetPromotedMetricsV2 = TweetOrganicMetricsV2;
 
+export interface SendTweetV2Params {
+  direct_message_deep_link?: string;
+  for_super_followers_only?: 'True' | 'False';
+  geo?: {
+    place_id: string;
+  };
+  media?: {
+    media_ids?: string[];
+    tagged_user_ids?: string[];
+  };
+  poll?: {
+    duration_minutes: number;
+    options: string[];
+  };
+  quote_tweet_id?: string;
+  reply?: {
+    exclude_reply_user_ids?: string[];
+    in_reply_to_tweet_id: string[];
+  };
+  reply_settings?: "mentionedUsers" | "following" | "everyone"
+}
+
 //// FINALLY, TweetV2
 export interface TweetV2 {
   id: string;

--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -116,6 +116,10 @@ export type TweetV2SingleStreamResult = TweetV2SingleResult & {
   matching_rules: { id: string | number, tag: string }[];
 };
 
+/// Tweet
+
+export type TweetV2PostTweetResult = DataV2<{ id: string, text: string }>;
+
 /// -- Replies --
 
 export type TweetV2HideReplyResult = DataV2<{ hidden: boolean }>;

--- a/src/v2/client.v2.write.ts
+++ b/src/v2/client.v2.write.ts
@@ -9,8 +9,10 @@ import type {
   ListPinV2Result,
   ListUpdateV2Params,
   ListUpdateV2Result,
+  SendTweetV2Params,
   TweetV2HideReplyResult,
   TweetV2LikeResult,
+  TweetV2PostTweetResult,
   TweetV2RetweetResult,
   UserV2BlockResult,
   UserV2FollowResult,
@@ -98,6 +100,17 @@ export default class TwitterApiv2ReadWrite extends TwitterApiv2ReadOnly {
     return this.delete<TweetV2RetweetResult>('users/:id/retweets/:tweet_id', undefined, {
       params: { id: loggedUserId, tweet_id: targetTweetId },
     });
+  }
+
+  /**
+ * Creates a Tweet on behalf of an authenticated user.
+ * https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets
+ */
+  public tweet(status: string, payload: Partial<SendTweetV2Params> = {}) {
+    return this.post<TweetV2PostTweetResult>('tweets', {
+      text: status,
+      ...payload
+    })
   }
 
   /* Users */

--- a/test/tweet.v2.test.ts
+++ b/test/tweet.v2.test.ts
@@ -140,4 +140,12 @@ describe('Tweets endpoints for v2 API', () => {
 
     expect(usersThatRt.data[0].created_at).to.be.a('string');
   }).timeout(60 * 1000);
+
+  it('.tweet - Creates a tweet', async () => {
+    const status = "Hello Twitter!"
+
+    const { data: { text } } = await client.v2.tweet(status)
+
+    expect(text).to.equal(status)
+  }).timeout(60 * 1000);
 });

--- a/test/tweet.v2.test.ts
+++ b/test/tweet.v2.test.ts
@@ -142,7 +142,7 @@ describe('Tweets endpoints for v2 API', () => {
   }).timeout(60 * 1000);
 
   it('.tweet - Creates a tweet', async () => {
-    const status = "Hello Twitter!"
+    const status = 'Hello Twitter!'
 
     const { data: { text } } = await client.v2.tweet(status)
 


### PR DESCRIPTION
Adds the v2 API endpoint for posting a tweet
Documentation followed at [POST Tweet](https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets)

PS: This project is really awesome, and valuable! Thanks for putting in the effort