### PR TITLE
feat: add v2 delete tweet

### DIFF
--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -134,6 +134,10 @@ export type TweetV2RetweetResult = DataV2<{ retweeted: boolean }>;
 
 export type TweetV2RetweetedByResult = DataMetaAndIncludeV2<UserV2[], { result_count: number }, ApiV2Includes>;
 
+/// Tweets
+
+export type TweetV2DeleteTweetResult = DataV2<{ deleted: boolean }>;
+
 /// -- Batch compliance
 
 export interface BatchComplianceJobV2 {

--- a/src/v2/client.v2.write.ts
+++ b/src/v2/client.v2.write.ts
@@ -9,6 +9,7 @@ import type {
   ListPinV2Result,
   ListUpdateV2Params,
   ListUpdateV2Result,
+  TweetV2DeleteTweetResult,
   TweetV2HideReplyResult,
   TweetV2LikeResult,
   TweetV2RetweetResult,
@@ -98,6 +99,18 @@ export default class TwitterApiv2ReadWrite extends TwitterApiv2ReadOnly {
     return this.delete<TweetV2RetweetResult>('users/:id/retweets/:tweet_id', undefined, {
       params: { id: loggedUserId, tweet_id: targetTweetId },
     });
+  }
+
+  /**
+   * Allows a user or authenticated user ID to delete a Tweet
+   * https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/delete-tweets-id
+   */
+  public deleteTweet(tweetId: string) {
+    return this.delete<TweetV2DeleteTweetResult>('tweets/:id', undefined, {
+      params: {
+        id: tweetId
+      }
+    })
   }
 
   /* Users */


### PR DESCRIPTION
Add method to delete tweet based on API doc at [Delete tweet](https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/delete-tweets-id)

PS: I'll like to add a test case for this after [Post tweet ](https://github.com/PLhery/node-twitter-api-v2/pull/110)  is merged, if a test is required 