### PR TITLE
Explicitly specify `userId` on `userMutingUsers`

### DIFF
--- a/src/v2/client.v2.read.ts
+++ b/src/v2/client.v2.read.ts
@@ -338,8 +338,7 @@ export default class TwitterApiv2ReadOnly extends TwitterApiSubClient {
    * Returns a list of users who are muted by the authenticating user.
    * https://developer.twitter.com/en/docs/twitter-api/users/mutes/api-reference/get-users-muting
    */
-  public async userMutingUsers(options: Partial<UserV2TimelineParams> = {}) {
-    const { id_str: userId } = await this.getCurrentUserObject();
+  public async userMutingUsers(userId: string, options: Partial<UserV2TimelineParams> = {}) {
     const params = { id: userId };
     const initialRq = await this.get<UserV2TimelineResult>('users/:id/muting', options, { fullResponse: true, params });
 


### PR DESCRIPTION
I have changed `userMutingUsers` to explicitly specify the `userId` just like `userBlockingUsers`.  
It avoids the errors in calling v1.1 API internally when users use the Essential Level of [Twitter API V2 Access Levels](https://developer.twitter.com/en/docs/twitter-api/getting-started/about-twitter-api#v2-access-level).  
This PR contains a breaking change, and if users have already used this API without specifying `userId`, the change will be required.