### PR TITLE
Fix wrong type for optional parameter images in TweetEntityUrlV2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test-stream": "npm run mocha test/stream.test.ts",
     "test-media": "npm run mocha test/media-upload.test.ts",
     "test-auth": "npm run mocha test/auth.test.ts",
-    "prepublish": "npm run build"
+    "prepublish": "yarn build"
   },
   "repository": "github:plhery/node-twitter-api-v2",
   "author": "Paul-Louis Hery <paullouis.hery+twitterapi@gmail.com> (https://twitter.com/plhery)",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test-stream": "npm run mocha test/stream.test.ts",
     "test-media": "npm run mocha test/media-upload.test.ts",
     "test-auth": "npm run mocha test/auth.test.ts",
-    "prepublish": "yarn build"
+    "prepublish": "npm run build"
   },
   "repository": "github:plhery/node-twitter-api-v2",
   "author": "Paul-Louis Hery <paullouis.hery+twitterapi@gmail.com> (https://twitter.com/plhery)",

--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -97,11 +97,13 @@ export interface TweetEntityUrlV2 {
   title?: string;
   description?: string;
   status?: string;
-  images?: {
-    url: string;
-    width: number;
-    height: number;
-  }
+  images?: TweetEntityUrlImageV2[];
+}
+
+export interface TweetEntityUrlImageV2 {
+  url: string;
+  width: number;
+  height: number;
 }
 
 export interface TweetEntityHashtagV2 {


### PR DESCRIPTION
The PR #42 introduced the optional property `images` to the `TweetEntityUrlV2`.  
Unfortunately, it assumed that the `images` property is only a single object.  
During some testing, the Twitter API V2 always returned an array of objects instead of a single object.  
The [official documentation](https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet) also shows that `images` is an array of objects.
```
 "entities": {
    "urls": [
        {
            "images": [
                {
                    "url": "https://pbs.twimg.com/news_img/1261301555787108354/9yR4UVsa?format=png&name=orig",
                    "width": 100,
                    "height": 100
                },
                {
                    "url": "https://pbs.twimg.com/news_img/1261301555787108354/9yR4UVsa?format=png&name=150x150",
                    "width": 100,
                    "height": 100
                }
            ],
        }
    ]
  },
```

This PR changes the type of `images` to an array of a new interface called `TweetEntityUrlImageV2`.