### PR TITLE
The options example for v2.me() doesn't make sense

### DIFF
--- a/doc/v2.md
+++ b/doc/v2.md
@@ -516,7 +516,7 @@ Get the logged user.
 
 **Example**
 ```ts
-const meUser = await client.v2.me({ 'tweet.fields': ['id', 'text'] });
+const meUser = await client.v2.me();
 ```
 
 ### <a name='Singleuser'></a>Single user

--- a/doc/v2.md
+++ b/doc/v2.md
@@ -516,7 +516,7 @@ Get the logged user.
 
 **Example**
 ```ts
-const meUser = await client.v2.me();
+const meUser = await client.v2.me({ expansions: ['pinned_tweet_id'] });
 ```
 
 ### <a name='Singleuser'></a>Single user


### PR DESCRIPTION
We can either provide a valid example or remove this "tweet.fields" one because this method doesn't return tweets.