### PR TITLE
feat: Pagination for tweet liked by / tweet retweeted by

### DIFF
--- a/doc/v2.md
+++ b/doc/v2.md
@@ -343,14 +343,20 @@ const tweets = await client.v2.tweets(['20', '141']);
 
 **Arguments**:
   - `tweetId: string`
-  - `options?: UsersV2Params`
+  - `options?: TweetRetweetedOrLikedByV2Params`
 
-**Returns**: `TweetV2LikedByResult`
+**Returns**: `TweetV2LikedByResult` or `TweetLikingUsersV2Paginator` (if `options.asPaginator`)
 
 **Example**
 ```ts
 const users = await client.v2.tweetLikedBy('20');
 console.log(users.data[0].id);
+
+const usersPaginated = await client.v2.tweetLikedBy('20', { asPaginator: true });
+
+for await (const user of usersPaginated) {
+  console.log(user.id);
+}
 ```
 
 ### <a name='Likeatweet'></a>Like a tweet
@@ -445,14 +451,20 @@ console.log(allTweetsWithNode.data[0].tweet_count);
 
 **Arguments**:
   - `tweetId: string`
-  - `options?: UsersV2Params`
+  - `options?: TweetRetweetedOrLikedByV2Params`
 
-**Returns**: `TweetV2RetweetedByResult`
+**Returns**: `TweetV2RetweetedByResult` or `TweetRetweetersUsersV2Paginator` (if `options.asPaginator`)
 
 **Example**
 ```ts
 const users = await client.v2.tweetRetweetedBy('20');
 console.log(users.data[0].id);
+
+const usersPaginated = await client.v2.tweetRetweetedBy('20', { asPaginator: true });
+
+for await (const user of usersPaginated) {
+  console.log(user.id);
+}
 ```
 
 ### <a name='Retweetatweet'></a>Retweet a tweet

--- a/src/paginators/user.paginator.v2.ts
+++ b/src/paginators/user.paginator.v2.ts
@@ -42,3 +42,11 @@ export class UserListMembersV2Paginator extends UserTimelineV2Paginator<UserV2Ti
 export class UserListFollowersV2Paginator extends UserTimelineV2Paginator<UserV2TimelineResult, UserV2TimelineParams, { id: string }> {
   protected _endpoint = 'lists/:id/followers';
 }
+
+export class TweetLikingUsersV2Paginator extends UserTimelineV2Paginator<UserV2TimelineResult, UserV2TimelineParams, { id: string }> {
+  protected _endpoint = 'tweets/:id/liking_users';
+}
+
+export class TweetRetweetersUsersV2Paginator extends UserTimelineV2Paginator<UserV2TimelineResult, UserV2TimelineParams, { id: string }> {
+  protected _endpoint = 'tweets/:id/retweeted_by';
+}

--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -130,13 +130,17 @@ export type TweetV2LikeResult = DataV2<{
   liked: boolean;
 }>;
 
-export type TweetV2LikedByResult = DataAndIncludeV2<UserV2[], ApiV2Includes>;
+export type TweetV2LikedByResult = DataMetaAndIncludeV2<UserV2[], {
+  result_count: number;
+  next_token?: string;
+  previous_token?: string;
+}, ApiV2Includes>;
 
 /// -- Retweets
 
 export type TweetV2RetweetResult = DataV2<{ retweeted: boolean }>;
 
-export type TweetV2RetweetedByResult = DataMetaAndIncludeV2<UserV2[], { result_count: number }, ApiV2Includes>;
+export type TweetV2RetweetedByResult = TweetV2LikedByResult;
 
 /// Tweets
 

--- a/src/types/v2/user.v2.types.ts
+++ b/src/types/v2/user.v2.types.ts
@@ -29,6 +29,18 @@ export interface UserV2TimelineParams {
   pagination_token?: string;
 }
 
+export interface TweetRetweetedOrLikedByV2Params extends Partial<UsersV2Params> {
+  asPaginator?: boolean;
+}
+
+export interface TweetRetweetedOrLikedByV2ParamsWithoutPaginator extends TweetRetweetedOrLikedByV2Params {
+  asPaginator?: false;
+}
+
+export interface TweetRetweetedOrLikedByV2ParamsWithPaginator extends TweetRetweetedOrLikedByV2Params {
+  asPaginator: true;
+}
+
 export interface FollowersV2Params extends UserV2TimelineParams {
   asPaginator?: boolean;
 }


### PR DESCRIPTION
- Add (optional) paginator support for `tweets/:id/liking_users` and `tweets/:id/retweeted_by` in v2 API. #165 