### PR TITLE
Fix README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm i twitter-api-v2
 Here's is a quick example of usage:
 
 ```ts
-import TwitterApi from 'twitter-api-v2';
+import { TwitterApi } from 'twitter-api-v2';
 
 // Instanciate with desired auth type (here's Bearer v2 auth)
 const twitterClient = new TwitterApi('<YOUR_APP_USER_TOKEN>');


### PR DESCRIPTION
Example is failing

```
$ node app.js            
file:///Users/snwfdhmp/Dev/workspaces/markets/scraping/app.js:15
  const twitterClient = new TwitterApi(
                        ^

TypeError: TwitterApi is not a constructor
    at main (file:///Users/snwfdhmp/Dev/workspaces/markets/scraping/app.js:15:25)
    at file:///Users/snwfdhmp/Dev/workspaces/markets/scraping/app.js:23:1
    at ModuleJob.run (node:internal/modules/esm/module_job:185:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12)
```
Using `import { TwitterApi } from "twitter-api-v2";` fixes it.