### PR TITLE
fixes: Paginator fix + failed response fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ yarn add twitter-api-v2
 npm i twitter-api-v2
 ```
 
-Here's is a quick example of usage:
+Here's a quick example of usage:
 
 ```ts
-import TwitterApi from 'twitter-api-v2';
+import { TwitterApi } from 'twitter-api-v2';
 
 // Instanciate with desired auth type (here's Bearer v2 auth)
 const twitterClient = new TwitterApi('<YOUR_APP_USER_TOKEN>');

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -1,17 +1,23 @@
 # Error handling
 
-When a request fails, you can catch a `ApiRequestError` or a `ApiResponseError` object (both instances of `Error`), that contain useful information about whats happening.
+When a request fails, you can catch a `ApiRequestError`, a `ApiPartialResponseError` or a `ApiResponseError` object (all instances of `Error`), that contain useful information about whats happening.
 
 - An `ApiRequestError` happens when the request **failed to sent** (network error, bad URL...).
+- An `ApiPartialResponseError` happens the response has been partially sent, but the connection is closed (by you, the OS or Twitter).
 - An `ApiResponseError` happens when **Twitter replies with an error**.
 
 Some properties are common for both objects:
 - `error` is `true`
-- `type` contains either `ETwitterApiError.Request` or `ETwitterApiError.Response` (depending of error)
+- `type` contains either `ETwitterApiError.Request`,  `ETwitterApiError.PartialResponse` or `ETwitterApiError.Response` (depending of error)
 - `request` containing node's raw `ClientRequest` instance
 
 ## Specific properties of `ApiRequestError`
 - `requestError`, an instance of `Error` that has been thrown through `request.on('error')` handler
+
+## Specific properties of `ApiPartialResponseError`
+- `responseError`, an instance of `Error` that has been thrown by `response.on('error')`, or by the tentative of parsing the result of a partial response
+- `response`, containing raw node's `IncomingMessage` instance
+- `rawContent`, containing all the chunks received from distant server
 
 ## Specific properties of `ApiResponseError`
 - `data`, containing parsed Twitter response data (type of `TwitterApiErrorData`)
@@ -26,7 +32,43 @@ Some properties are common for both objects:
 ## Specific methods of `ApiResponseError`
 - `hasErrorCode(code: number | EApiV1ErrorCode | EApiV2ErrorCode)`: Tells if given Twitter error code is present in error response
 
-## Debug your requests
+## Advanced: Debug a single request
+
+If you want to debug a single request made through direct HTTP handlers `.get`/`.post`/`.delete`,
+you can use an additionnal property named `requestEventDebugHandler`.
+
+```ts
+client.v1.get(
+  'statuses/user_timeline.json',
+  { user_id: 10, count: 200 },
+  { requestEventDebugHandler: (eventType, data) => console.log('Event', eventType, 'with data', data) },
+)
+```
+
+It takes a function of type `(event: TRequestDebuggerHandlerEvent, data?: any) => void` where available events are:
+```ts
+type TRequestDebuggerHandlerEvent = 'abort' | 'socket' | 'socket-error' | 'socket-connect'
+  | 'socket-close' | 'socket-end' | 'socket-lookup' | 'socket-timeout' | 'request-error'
+  | 'response' | 'response-aborted' | 'response-error' | 'response-close' | 'response-end';
+```
+
+`data` parameter associated to events:
+- `abort`: None / `abort` event of `request`
+- `socket`: `{ socket: Socket }` / `request.socket` object, when it is available through `request.on('socket')`
+- `socket-error`: `{ socket: Socket, error: Error }` / `error` event of `request.socket`
+- `socket-connect`: `{ socket: Socket }` / `connect` event of `request.socket`
+- `socket-close`: `{ socket: Socket, withError: boolean }` / `close` event of `request.socket`
+- `socket-end`: `{ socket: Socket }` / `end` event of `request.socket`
+- `socket-lookup`: `{ socket: Socket, data: [err: Error?, address: string, family: string | number, host: string] }` / `lookup` event of `request.socket`
+- `socket-timeout`: `{ socket: Socket }` / `timeout` event of `request.socket`
+- `request-error`: `{ requestError: Error }` / `error` event of `request`
+- `response`: `{ res: IncomingMessage }` / `response` object, when it is available through `request.on('response')`
+- `response-aborted`: `{ error?: Error }` / `aborted` event of `response`
+- `response-error`: `{ error: Error }` / `error` event of `response`
+- `response-close`: `{ data: string }` (raw response data) / `close` event of `response`
+- `response-end`: None / `end` event of `response`
+
+## Advanced: Debug all made requests
 
 If you keep obtaining errors and you don't know how to obtain the response data, or you want to see exactly what have been sent to Twitter,
 you can enable the debug mode:

--- a/src/client-mixins/request-handler.helper.ts
+++ b/src/client-mixins/request-handler.helper.ts
@@ -213,13 +213,10 @@ export class RequestHandlerHelper<T> {
         this.getParsedResponse(this.res);
         // Ok, try to resolve normally the request
         return this.onResponseEndHandler(resolve, reject);
-      } catch (e) {}
-
-      // Parse error, just drop with content
-      return reject(this.createPartialResponseError(
-        new Error('Response has been interrupted and partial response could not be parsed.'),
-        true,
-      ));
+      } catch (e) {
+        // Parse error, just drop with content
+        return reject(this.createPartialResponseError(e as Error, true));
+      }
     }
     if (!res.complete) {
       return reject(this.createPartialResponseError(

--- a/src/client-mixins/request-handler.helper.ts
+++ b/src/client-mixins/request-handler.helper.ts
@@ -139,7 +139,7 @@ export class RequestHandlerHelper<T> {
 
     if (this.requestData.debug) {
       res.on('error', error => this.requestData.debug?.stepLogger('response-error', { uuid: this.requestData.debug.uuid, error }))
-      res.on('close', () => this.requestData.debug?.stepLogger('response-close', { uuid: this.requestData.debug.uuid }))
+      res.on('close', () => this.requestData.debug?.stepLogger('response-close', { uuid: this.requestData.debug.uuid, data: this.responseData }))
       res.on('end', () => this.requestData.debug?.stepLogger('response-end', { uuid: this.requestData.debug.uuid }))
     }
 

--- a/src/client-mixins/request-handler.helper.ts
+++ b/src/client-mixins/request-handler.helper.ts
@@ -138,6 +138,7 @@ export class RequestHandlerHelper<T> {
     this.requestData.debug?.stepLogger('response', { uuid: this.requestData.debug.uuid, res })
 
     if (this.requestData.debug) {
+      res.on('aborted', error => this.requestData.debug?.stepLogger('response-aborted', { uuid: this.requestData.debug.uuid, error }))
       res.on('error', error => this.requestData.debug?.stepLogger('response-error', { uuid: this.requestData.debug.uuid, error }))
       res.on('close', () => this.requestData.debug?.stepLogger('response-close', { uuid: this.requestData.debug.uuid, data: this.responseData }))
       res.on('end', () => this.requestData.debug?.stepLogger('response-end', { uuid: this.requestData.debug.uuid }))

--- a/src/client-mixins/request-maker.mixin.ts
+++ b/src/client-mixins/request-maker.mixin.ts
@@ -58,7 +58,7 @@ interface IGetStreamRequestArgsSync {
   autoConnect: false;
 }
 
-export type TCustomizableRequestArgs = Pick<IGetHttpRequestArgs, 'headers' | 'params' | 'forceBodyMode' | 'enableAuth' | 'enableRateLimitSave'>;
+export type TCustomizableRequestArgs = Pick<IGetHttpRequestArgs, 'timeout' | 'headers' | 'params' | 'forceBodyMode' | 'enableAuth' | 'enableRateLimitSave'>;
 
 export abstract class ClientRequestMaker {
   protected _bearerToken?: string;

--- a/src/client-mixins/request-maker.mixin.ts
+++ b/src/client-mixins/request-maker.mixin.ts
@@ -1,71 +1,12 @@
 import { IClientSettings, TwitterRateLimit, TwitterResponse } from '../types';
 import TweetStream from '../stream/TweetStream';
-import type { RequestOptions } from 'https';
 import type { ClientRequestArgs } from 'http';
 import { trimUndefinedProperties } from '../helpers';
 import OAuth1Helper from './oauth1.helper';
 import RequestHandlerHelper from './request-handler.helper';
 import RequestParamHelpers from './request-param.helper';
 import { OAuth2Helper } from './oauth2.helper';
-
-interface IDebugRequest<TUuid = number | string> {
-  uuid: TUuid;
-  stepLogger: (phaseOrEvent: string, data: any) => void,
-}
-
-export type TRequestFullData = {
-  url: URL,
-  options: RequestOptions,
-  body?: any,
-  rateLimitSaver?: (rateLimit: TwitterRateLimit) => any,
-  debug?: IDebugRequest,
-};
-export type TRequestFullStreamData = TRequestFullData & { payloadIsError?: (data: any) => boolean };
-export type TRequestQuery = Record<string, string | number | boolean | string[] | undefined>;
-export type TRequestStringQuery = Record<string, string>;
-export type TRequestBody = Record<string, any> | Buffer;
-export type TBodyMode = 'json' | 'url' | 'form-data' | 'raw';
-
-interface IWriteAuthHeadersArgs {
-  headers: Record<string, string>;
-  bodyInSignature: boolean;
-  url: URL;
-  method: string;
-  query: TRequestQuery;
-  body: TRequestBody;
-}
-
-export interface IGetHttpRequestArgs {
-  url: string;
-  method: string;
-  query?: TRequestQuery;
-  /** The URL parameters, if you specify an endpoint with `:id`, for example. */
-  params?: TRequestQuery;
-  body?: TRequestBody;
-  headers?: Record<string, string>;
-  forceBodyMode?: TBodyMode;
-  enableAuth?: boolean;
-  enableRateLimitSave?: boolean;
-  timeout?: number;
-  debug?: IDebugRequest;
-}
-
-export interface IGetStreamRequestArgs {
-  payloadIsError?: (data: any) => boolean;
-  autoConnect?: boolean;
-}
-
-interface IGetStreamRequestArgsAsync {
-  payloadIsError?: (data: any) => boolean;
-  autoConnect?: true;
-}
-
-interface IGetStreamRequestArgsSync {
-  payloadIsError?: (data: any) => boolean;
-  autoConnect: false;
-}
-
-export type TCustomizableRequestArgs = Pick<IGetHttpRequestArgs, 'timeout' | 'headers' | 'params' | 'forceBodyMode' | 'enableAuth' | 'enableRateLimitSave'>;
+import type { IGetHttpRequestArgs, IGetStreamRequestArgs, IGetStreamRequestArgsAsync, IGetStreamRequestArgsSync, IWriteAuthHeadersArgs, TRequestFullStreamData } from '../types/request-maker.mixin.types';
 
 export abstract class ClientRequestMaker {
   protected _bearerToken?: string;
@@ -106,7 +47,7 @@ export abstract class ClientRequestMaker {
       options,
       body: args.body,
       rateLimitSaver: enableRateLimitSave ? this.saveRateLimit.bind(this, args.rawUrl) : undefined,
-      debug: requestParams.debug,
+      requestEventDebugHandler: requestParams.requestEventDebugHandler,
     })
       .makeRequest();
   }

--- a/src/client-mixins/request-maker.mixin.ts
+++ b/src/client-mixins/request-maker.mixin.ts
@@ -47,6 +47,7 @@ export interface IGetHttpRequestArgs {
   enableAuth?: boolean;
   enableRateLimitSave?: boolean;
   timeout?: number;
+  debug?: IDebugRequest;
 }
 
 export interface IGetStreamRequestArgs {
@@ -105,6 +106,7 @@ export abstract class ClientRequestMaker {
       options,
       body: args.body,
       rateLimitSaver: enableRateLimitSave ? this.saveRateLimit.bind(this, args.rawUrl) : undefined,
+      debug: requestParams.debug,
     })
       .makeRequest();
   }

--- a/src/client-mixins/request-maker.mixin.ts
+++ b/src/client-mixins/request-maker.mixin.ts
@@ -8,11 +8,17 @@ import RequestHandlerHelper from './request-handler.helper';
 import RequestParamHelpers from './request-param.helper';
 import { OAuth2Helper } from './oauth2.helper';
 
+interface IDebugRequest<TUuid = number | string> {
+  uuid: TUuid;
+  stepLogger: (phaseOrEvent: string, data: any) => void,
+}
+
 export type TRequestFullData = {
   url: URL,
   options: RequestOptions,
   body?: any,
   rateLimitSaver?: (rateLimit: TwitterRateLimit) => any,
+  debug?: IDebugRequest,
 };
 export type TRequestFullStreamData = TRequestFullData & { payloadIsError?: (data: any) => boolean };
 export type TRequestQuery = Record<string, string | number | boolean | string[] | undefined>;

--- a/src/client-mixins/request-param.helper.ts
+++ b/src/client-mixins/request-param.helper.ts
@@ -1,6 +1,6 @@
 import { FormDataHelper } from './form-data.helper';
 import type { RequestOptions } from 'https';
-import type { TBodyMode, TRequestBody, TRequestQuery, TRequestStringQuery } from './request-maker.mixin';
+import type { TBodyMode, TRequestBody, TRequestQuery, TRequestStringQuery } from '../types/request-maker.mixin.types';
 
 /* Helpers functions that are specific to this class but do not depends on instance */
 

--- a/src/client.base.ts
+++ b/src/client.base.ts
@@ -1,13 +1,11 @@
 import type { IClientSettings, TClientTokens, TwitterApiBasicAuth, TwitterApiOAuth2Init, TwitterApiTokens, TwitterRateLimit, TwitterResponse, UserV1, UserV2Result } from './types';
 import {
   ClientRequestMaker,
-  TCustomizableRequestArgs,
-  TRequestBody,
-  TRequestQuery,
 } from './client-mixins/request-maker.mixin';
 import TweetStream from './stream/TweetStream';
 import { sharedPromise, SharedPromise } from './helpers';
 import { API_V1_1_PREFIX, API_V2_PREFIX } from './globals';
+import type { TCustomizableRequestArgs, TRequestBody, TRequestQuery } from './types/request-maker.mixin.types';
 
 export type TGetClientRequestArgs = TCustomizableRequestArgs & {
   prefix?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,3 @@ export * from './types';
 export * from './paginators';
 export * from './stream/TweetStream';
 export * from './settings';
-export { IGetHttpRequestArgs } from './client-mixins/request-maker.mixin';

--- a/src/paginators/TwitterPaginator.ts
+++ b/src/paginators/TwitterPaginator.ts
@@ -1,6 +1,6 @@
 import { TwitterRateLimit, TwitterResponse } from '../types';
 import TwitterApiSubClient from '../client.subclient';
-import { TRequestQuery } from '../client-mixins/request-maker.mixin';
+import type { TRequestQuery } from '../types/request-maker.mixin.types';
 
 export interface ITwitterPaginatorArgs<TApiResult, TApiParams, TParams> {
   realData: TApiResult;

--- a/src/paginators/v2.paginator.ts
+++ b/src/paginators/v2.paginator.ts
@@ -134,6 +134,6 @@ export abstract class TimelineV2Paginator<
   }
 
   protected canFetchNextPage(result: TResult) {
-    return !!result.meta.next_token;
+    return !!result.meta?.next_token;
   }
 }

--- a/src/stream/TweetStream.ts
+++ b/src/stream/TweetStream.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'events';
 import type { IncomingMessage, ClientRequest } from 'http';
 import RequestHandlerHelper from '../client-mixins/request-handler.helper';
-import { TRequestFullStreamData } from '../client-mixins/request-maker.mixin';
 import { ETwitterStreamEvent } from '../types';
+import { TRequestFullStreamData } from '../types/request-maker.mixin.types';
 import TweetStreamEventCombiner from './TweetStreamEventCombiner';
 import TweetStreamParser, { EStreamParserEvent } from './TweetStreamParser';
 

--- a/src/types/errors.types.ts
+++ b/src/types/errors.types.ts
@@ -113,7 +113,6 @@ interface IBuildApiPartialRequestError {
   readonly request: ClientRequest;
   readonly response: IncomingMessage;
   readonly rawContent: string;
-  readonly content?: any;
   responseError: Error;
 }
 
@@ -145,10 +144,6 @@ export class ApiPartialResponseError extends ApiError implements IBuildApiPartia
 
   get rawContent(): string {
     return this._options.rawContent;
-  }
-
-  get content(): unknown {
-    return this._options.content;
   }
 
   toJSON() {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './errors.types';
 export * from './responses.types';
 export * from './client.types';
 export * from './auth.types';
+export { IGetHttpRequestArgs } from './request-maker.mixin.types';

--- a/src/types/request-maker.mixin.types.ts
+++ b/src/types/request-maker.mixin.types.ts
@@ -1,0 +1,63 @@
+import type { RequestOptions } from 'https';
+import type { TwitterRateLimit } from './responses.types';
+
+export type TRequestDebuggerHandlerEvent = 'abort' | 'socket' | 'socket-error' | 'socket-connect'
+  | 'socket-close' | 'socket-end' | 'socket-lookup' | 'socket-timeout' | 'request-error'
+  | 'response' | 'response-aborted' | 'response-error' | 'response-close' | 'response-end';
+export type TRequestDebuggerHandler = (event: TRequestDebuggerHandlerEvent, data?: any) => void;
+
+export type TRequestFullData = {
+  url: URL,
+  options: RequestOptions,
+  body?: any,
+  rateLimitSaver?: (rateLimit: TwitterRateLimit) => any,
+  requestEventDebugHandler?: TRequestDebuggerHandler,
+};
+
+export type TRequestFullStreamData = TRequestFullData & { payloadIsError?: (data: any) => boolean };
+export type TRequestQuery = Record<string, string | number | boolean | string[] | undefined>;
+export type TRequestStringQuery = Record<string, string>;
+export type TRequestBody = Record<string, any> | Buffer;
+export type TBodyMode = 'json' | 'url' | 'form-data' | 'raw';
+
+export interface IWriteAuthHeadersArgs {
+  headers: Record<string, string>;
+  bodyInSignature: boolean;
+  url: URL;
+  method: string;
+  query: TRequestQuery;
+  body: TRequestBody;
+}
+
+export interface IGetHttpRequestArgs {
+  url: string;
+  method: string;
+  query?: TRequestQuery;
+  /** The URL parameters, if you specify an endpoint with `:id`, for example. */
+  params?: TRequestQuery;
+  body?: TRequestBody;
+  headers?: Record<string, string>;
+  forceBodyMode?: TBodyMode;
+  enableAuth?: boolean;
+  enableRateLimitSave?: boolean;
+  timeout?: number;
+  requestEventDebugHandler?: TRequestDebuggerHandler;
+}
+
+export interface IGetStreamRequestArgs {
+  payloadIsError?: (data: any) => boolean;
+  autoConnect?: boolean;
+  }
+
+export interface IGetStreamRequestArgsAsync {
+  payloadIsError?: (data: any) => boolean;
+  autoConnect?: true;
+}
+
+export interface IGetStreamRequestArgsSync {
+  payloadIsError?: (data: any) => boolean;
+  autoConnect: false;
+}
+
+export type TCustomizableRequestArgs = Pick<IGetHttpRequestArgs, 'timeout' | 'headers' | 'params' | 'forceBodyMode' | 'enableAuth' | 'enableRateLimitSave'>;
+


### PR DESCRIPTION
Fix two different issues:
- Crash when a v2 paginator is empty and response does not contains a `.meta` property #177 
- "Memory leak" when response are abruptly closed by Twitter or OS, because no close/error listener on response object was attributed

Add a way to precisely debug requests through HTTP handlers.