### PR TITLE
fix: Fix OAuth 2 scope encoding

### DIFF
--- a/src/client-mixins/oauth1.helper.ts
+++ b/src/client-mixins/oauth1.helper.ts
@@ -37,6 +37,15 @@ export class OAuth1Helper {
     this.consumerKeys = options.consumerKeys;
   }
 
+  static percentEncode(str: string) {
+    return encodeURIComponent(str)
+      .replace(/!/g, '%21')
+      .replace(/\*/g, '%2A')
+      .replace(/'/g, '%27')
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29');
+  }
+
   protected hash(base: string, key: string) {
     return crypto
       .createHmac('sha1', key)
@@ -75,7 +84,7 @@ export class OAuth1Helper {
         continue;
       }
 
-      header_value += percentEncode(element.key) + '="' + percentEncode(element.value as string) + '",';
+      header_value += OAuth1Helper.percentEncode(element.key) + '="' + OAuth1Helper.percentEncode(element.value as string) + '",';
     }
 
     return {
@@ -107,13 +116,13 @@ export class OAuth1Helper {
   }
 
   protected getSigningKey(tokenSecret: string | undefined) {
-    return percentEncode(this.consumerKeys.secret) + '&' + percentEncode(tokenSecret || '');
+    return OAuth1Helper.percentEncode(this.consumerKeys.secret) + '&' + OAuth1Helper.percentEncode(tokenSecret || '');
   }
 
   protected getBaseString(request: OAuth1RequestOptions, oauthInfo: OAuth1AuthInfo) {
     return request.method.toUpperCase() + '&'
-      + percentEncode(this.getBaseUrl(request.url)) + '&'
-      + percentEncode(this.getParameterString(request, oauthInfo));
+      + OAuth1Helper.percentEncode(this.getBaseUrl(request.url)) + '&'
+      + OAuth1Helper.percentEncode(this.getParameterString(request, oauthInfo));
   }
 
   protected getParameterString(request: OAuth1RequestOptions, oauthInfo: OAuth1AuthInfo) {
@@ -211,15 +220,6 @@ function deParamUrl(url: string) {
   return deParam(tmp[1]);
 }
 
-function percentEncode(str: string) {
-  return encodeURIComponent(str)
-    .replace(/!/g, '%21')
-    .replace(/\*/g, '%2A')
-    .replace(/'/g, '%27')
-    .replace(/\(/g, '%28')
-    .replace(/\)/g, '%29');
-}
-
 function percentEncodeData<T>(data: T): T {
   const result: any = {};
 
@@ -228,12 +228,12 @@ function percentEncodeData<T>(data: T): T {
 
     // check if the value is an array
     if (value && Array.isArray(value)){
-      value = value.map(v => percentEncode(v));
+      value = value.map(v => OAuth1Helper.percentEncode(v));
     } else {
-      value = percentEncode(value);
+      value = OAuth1Helper.percentEncode(value);
     }
 
-    result[percentEncode(key)] = value;
+    result[OAuth1Helper.percentEncode(key)] = value;
   }
 
   return result;

--- a/src/client-mixins/request-param.helper.ts
+++ b/src/client-mixins/request-param.helper.ts
@@ -1,6 +1,7 @@
 import { FormDataHelper } from './form-data.helper';
 import type { RequestOptions } from 'https';
 import type { TBodyMode, TRequestBody, TRequestQuery, TRequestStringQuery } from '../types/request-maker.mixin.types';
+import OAuth1Helper from './oauth1.helper';
 
 /* Helpers functions that are specific to this class but do not depends on instance */
 
@@ -55,13 +56,16 @@ export class RequestParamHelpers {
   }
 
   static addQueryParamsToUrl(url: URL, query: TRequestQuery) {
-    for (const [key, value] of Object.entries(query) as [string, string][]) {
-      url.searchParams.append(key, value);
-    }
+    const queryEntries = Object.entries(query) as [string, string][];
 
-    if (url.search) {
-      // URLSearchParams doesnt encode '*', but Twitter wants it encoded.
-      url.search = url.search.replace(/\*/g, '%2A');
+    if (queryEntries.length) {
+      let search = '';
+
+      for (const [key, value] of queryEntries) {
+        search += (search.length ? '&' : '?') + `${OAuth1Helper.percentEncode(key)}=${OAuth1Helper.percentEncode(value)}`;
+      }
+
+      url.search = search;
     }
   }
 

--- a/src/client/readonly.ts
+++ b/src/client/readonly.ts
@@ -13,6 +13,7 @@ import {
 import TwitterApiv1ReadOnly from '../v1/client.v1.read';
 import TwitterApiv2ReadOnly from '../v2/client.v2.read';
 import { OAuth2Helper } from '../client-mixins/oauth2.helper';
+import RequestParamHelpers from '../client-mixins/request-param.helper';
 
 /**
  * Twitter v1.1 and v2 API client.
@@ -217,13 +218,17 @@ export default class TwitterApiReadOnly extends TwitterApiBase {
     const scope = Array.isArray(rawScope) ? rawScope.join(' ') : rawScope;
 
     const url = new URL('https://twitter.com/i/oauth2/authorize');
-    url.searchParams.set('response_type', 'code');
-    url.searchParams.set('client_id', this._clientId);
-    url.searchParams.set('redirect_uri', redirectUri);
-    url.searchParams.set('state', state);
-    url.searchParams.set('code_challenge', codeChallenge);
-    url.searchParams.set('code_challenge_method', 's256');
-    url.searchParams.set('scope', scope);
+    const query = {
+      response_type: 'code',
+      client_id: this._clientId,
+      redirect_uri: redirectUri,
+      state,
+      code_challenge: codeChallenge,
+      code_challenge_method: 's256',
+      scope,
+    };
+
+    RequestParamHelpers.addQueryParamsToUrl(url, query);
 
     return {
       url: url.toString(),


### PR DESCRIPTION
Due to a misusage of `.searchParams` of `URL` object, that don't correctly encode all URI components, scope was generated incorrectly.

Removed every usage of `.searchParams` in the project to avoid other errors.

Addresses #184 