### PR TITLE
chore(doc): fix the links to http wrappers doc

### DIFF
--- a/doc/v1.md
+++ b/doc/v1.md
@@ -6,7 +6,7 @@ This is a comprehensive guide of all methods available for the Twitter API v1.1 
 >
 > If you don't find the endpoint you want, don't panic! It probably hasn't been implemented yet.
 > You can make your request manually using generic requests handlers `.get`, `.post`, `.put`, `.patch` and `.delete` methods.
-> See [Use direct HTTP methods wrappers](./basics.md#use-the-direct-http-methods-wrappers) in the Basics.
+> See the [HTTP wrappers](./http-wrappers.md) documentation.
 
 *Argument note*: Described arguments often refers to an interface name. Generally, argument type is a `Partial<>` (all properties are optionals) of the given interface.
 

--- a/doc/v2.md
+++ b/doc/v2.md
@@ -6,7 +6,7 @@ This is a comprehensive guide of all methods available for the Twitter API v2 on
 >
 > If you don't find the endpoint you want, don't panic! It probably hasn't been implemented yet.
 > You can make your request manually using generic requests handlers `.get`, `.post`, `.put`, `.patch` and `.delete` methods.
-> See [Use direct HTTP methods wrappers](./basics.md#use-the-direct-http-methods-wrappers) in the Basics.
+> See the [HTTP wrappers](./http-wrappers.md) documentation.
 
 *Argument note*: Described arguments often refers to an interface name. Generally, argument type is a `Partial<>` (all properties are optionals) of the given interface.
 


### PR DESCRIPTION
HTTP wrappers (.get, .post...) doc has been moved from basics to its own section ; though the links to it were not updated.