### PR TITLE
Feat: DM image getter

### DIFF
--- a/doc/v1.md
+++ b/doc/v1.md
@@ -63,6 +63,7 @@ For streaming API, see [Streaming part](./streaming.md).
 	* [Get a single DM by ID](#GetasingleDMbyID)
 	* [Delete / hide a DM](#DeletehideaDM)
 	* [List sent and received DMs](#ListsentandreceivedDMs)
+	* [Download a media attached in a DM](#DownloadamediaattachedinaDM)
 	* [Create a welcome direct message](#Createawelcomedirectmessage)
 	* [Get a welcome direct message (that you own)](#Getawelcomedirectmessagethatyouown)
 	* [Delete a welcome direct message (that you own)](#Deleteawelcomedirectmessagethatyouown)
@@ -1076,6 +1077,34 @@ const eventsPaginator = await client.v1.listDmEvents();
 for await (const event of eventsPaginator) {
   if (event.type === EDirectMessageEventTypeV1.Create) {
     console.log('Sender ID is', event[EDirectMessageEventTypeV1.Create].sender_id);
+  }
+}
+```
+
+### <a name='DownloadamediaattachedinaDM'></a>Download a media attached in a DM
+
+Medias linked to direct messages are protected under user authentication on Twitter.
+You can download them using this wrapper which handles the OAuth boilerplate for you.
+
+**Method**: `.downloadDmImage()`
+
+**Endpoint**: *None*
+
+**Right level**: `Read-write + DM`
+
+**Arguments**:
+  - `urlOrDm: string | DirectMessageCreateV1`: Direct media URL or direct message. Message must contain an attachment.
+
+**Returns**: `Buffer`
+
+**Example**
+```ts
+const eventsPaginator = await client.v1.listDmEvents();
+
+for await (const event of eventsPaginator) {
+  // If message is a direct message and has an attachment
+  if (event.type === EDirectMessageEventTypeV1.Create && event[EDirectMessageEventTypeV1.Create].message_data.attachment) {
+    const image = await client.v1.downloadDmImage(event);
   }
 }
 ```

--- a/src/client-mixins/request-maker.mixin.ts
+++ b/src/client-mixins/request-maker.mixin.ts
@@ -86,6 +86,7 @@ export class ClientRequestMaker {
       rateLimitSaver: enableRateLimitSave ? this.saveRateLimit.bind(this, args.rawUrl) : undefined,
       requestEventDebugHandler: requestParams.requestEventDebugHandler,
       compression: requestParams.compression ?? this.clientSettings.compression ?? true,
+      forceParseMode: requestParams.forceParseMode,
     })
       .makeRequest();
 

--- a/src/types/request-maker.mixin.types.ts
+++ b/src/types/request-maker.mixin.types.ts
@@ -1,5 +1,4 @@
 import type { RequestOptions } from 'https';
-import type TwitterApiBase from '../client.base';
 import type { TwitterApiBasicAuth, TwitterApiOAuth2Init, TwitterApiTokens } from './client.types';
 import type { TwitterRateLimit } from './responses.types';
 
@@ -21,6 +20,7 @@ export type TRequestFullData = {
   rateLimitSaver?: (rateLimit: TwitterRateLimit) => any,
   requestEventDebugHandler?: TRequestDebuggerHandler,
   compression?: TRequestCompressionLevel,
+  forceParseMode?: TResponseParseMode,
 };
 
 export type TRequestFullStreamData = TRequestFullData & { payloadIsError?: (data: any) => boolean };
@@ -28,6 +28,7 @@ export type TRequestQuery = Record<string, string | number | boolean | string[] 
 export type TRequestStringQuery = Record<string, string>;
 export type TRequestBody = Record<string, any> | Buffer;
 export type TBodyMode = 'json' | 'url' | 'form-data' | 'raw';
+export type TResponseParseMode = 'json' | 'url' | 'text' | 'buffer' | 'none';
 
 export interface IWriteAuthHeadersArgs {
   headers: Record<string, string>;
@@ -47,6 +48,7 @@ export interface IGetHttpRequestArgs {
   body?: TRequestBody;
   headers?: Record<string, string>;
   forceBodyMode?: TBodyMode;
+  forceParseMode?: TResponseParseMode;
   enableAuth?: boolean;
   enableRateLimitSave?: boolean;
   timeout?: number;
@@ -77,6 +79,6 @@ export interface IGetStreamRequestArgsSync {
   autoConnect: false;
 }
 
-export type TCustomizableRequestArgs = Pick<IGetHttpRequestArgs, 'compression' | 'timeout' | 'headers' | 'params' | 'forceBodyMode' | 'enableAuth' | 'enableRateLimitSave'>;
+export type TCustomizableRequestArgs = Pick<IGetHttpRequestArgs, 'forceParseMode' | 'compression' | 'timeout' | 'headers' | 'params' | 'forceBodyMode' | 'enableAuth' | 'enableRateLimitSave'>;
 
 export type TAcceptedInitToken = TwitterApiTokens | TwitterApiOAuth2Init | TwitterApiBasicAuth | string;

--- a/src/v1/client.v1.ts
+++ b/src/v1/client.v1.ts
@@ -14,6 +14,7 @@ import {
   WelcomeDirectMessageListV1Result,
   WelcomeDmRuleV1Result,
   WelcomeDmRuleListV1Result,
+  DirectMessageCreateV1,
 } from '../types';
 import TwitterApiv1ReadWrite from './client.v1.write';
 
@@ -241,6 +242,26 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
     return this.post<void>('direct_messages/indicate_typing.json', {
       recipient_id: recipientId,
     }, { forceBodyMode: 'url' });
+  }
+
+  // Part: Images
+
+  /**
+   * Marks a message as read in the recipient’s Direct Message conversation view with the sender.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-read-receipt
+   */
+  public downloadDmImage(urlOrDm: string | DirectMessageCreateV1) {
+    if (typeof urlOrDm !== 'string') {
+      const attachment = urlOrDm[EDirectMessageEventTypeV1.Create].message_data.attachment;
+
+      if (!attachment) {
+        throw new Error('Given direct message doesnt contain attachment');
+      }
+
+      urlOrDm = attachment.media_url_https;
+    }
+
+    return this.get<Buffer>(urlOrDm, undefined, { forceParseMode: 'buffer', prefix: '' });
   }
 }
 

--- a/src/v1/client.v1.ts
+++ b/src/v1/client.v1.ts
@@ -255,7 +255,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
       const attachment = urlOrDm[EDirectMessageEventTypeV1.Create].message_data.attachment;
 
       if (!attachment) {
-        throw new Error('Given direct message doesnt contain attachment');
+        throw new Error('The given direct message doesn\'t contain any attachment');
       }
 
       urlOrDm = attachment.media_url_https;

--- a/src/v1/client.v1.ts
+++ b/src/v1/client.v1.ts
@@ -247,8 +247,8 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
   // Part: Images
 
   /**
-   * Marks a message as read in the recipient’s Direct Message conversation view with the sender.
-   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-read-receipt
+   * Get a single image attached to a direct message. TwitterApi client must be logged with OAuth 1.0a.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/message-attachments/guides/retrieving-media
    */
   public downloadDmImage(urlOrDm: string | DirectMessageCreateV1) {
     if (typeof urlOrDm !== 'string') {

--- a/src/v1/client.v1.ts
+++ b/src/v1/client.v1.ts
@@ -250,7 +250,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
    * Get a single image attached to a direct message. TwitterApi client must be logged with OAuth 1.0a.
    * https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/message-attachments/guides/retrieving-media
    */
-  public downloadDmImage(urlOrDm: string | DirectMessageCreateV1) {
+  public async downloadDmImage(urlOrDm: string | DirectMessageCreateV1) {
     if (typeof urlOrDm !== 'string') {
       const attachment = urlOrDm[EDirectMessageEventTypeV1.Create].message_data.attachment;
 
@@ -261,7 +261,12 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
       urlOrDm = attachment.media_url_https;
     }
 
-    return this.get<Buffer>(urlOrDm, undefined, { forceParseMode: 'buffer', prefix: '' });
+    const data = await this.get<Buffer>(urlOrDm, undefined, { forceParseMode: 'buffer', prefix: '' });
+    if (!data.length) {
+      throw new Error('Image not found. Make sure you are logged with credentials able to access direct messages, and check the URL.');
+    }
+
+    return data;
   }
 }
 


### PR DESCRIPTION
Made small tweaks to allow image download from `ton.twitter.com`, which needs OAuth 1.0a signature to download DM images

Implement a new getter, `.downloadDmImage()`, available on `.v1` (with DM rights).