### PR TITLE
add .quote method to v1ReadWrite

### DIFF
--- a/src/v1/client.v1.write.ts
+++ b/src/v1/client.v1.write.ts
@@ -61,6 +61,17 @@ export default class TwitterApiv1ReadWrite extends TwitterApiv1ReadOnly {
   }
 
   /**
+   * Quote an existing tweet.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update
+   */
+  public async quote(status: string, quoting_status_id: string, payload: Partial<SendTweetV1Params> = {}) {
+    const { user: { screen_name: quoted_user_name } } = await this.singleTweet(quoting_status_id)
+    const quoted_status_url = new URL('https://twitter.com/' + quoted_user_name + '/status/' + quoting_status_id)
+    
+    return this.tweet(status + ' ' + quoted_status_url.toString(), payload)
+  }
+
+  /**
    * Post a series of tweets.
    * https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update
    */

--- a/src/v1/client.v1.write.ts
+++ b/src/v1/client.v1.write.ts
@@ -64,8 +64,8 @@ export default class TwitterApiv1ReadWrite extends TwitterApiv1ReadOnly {
    * Quote an existing tweet.
    * https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update
    */
-  public async quote(status: string, quoting_status_id: string, payload: Partial<SendTweetV1Params> = {}) {
-    const url = 'https://twitter.com/i/statuses/' + quoting_status_id;
+  public async quote(status: string, quotingStatusId: string, payload: Partial<SendTweetV1Params> = {}) {
+    const url = 'https://twitter.com/i/statuses/' + quotingStatusId;
     return this.tweet(status, { ...payload, attachment_url: url });
   }
 

--- a/src/v1/client.v1.write.ts
+++ b/src/v1/client.v1.write.ts
@@ -65,10 +65,8 @@ export default class TwitterApiv1ReadWrite extends TwitterApiv1ReadOnly {
    * https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update
    */
   public async quote(status: string, quoting_status_id: string, payload: Partial<SendTweetV1Params> = {}) {
-    const { user: { screen_name: quoted_user_name } } = await this.singleTweet(quoting_status_id)
-    const quoted_status_url = new URL('https://twitter.com/' + quoted_user_name + '/status/' + quoting_status_id)
-    
-    return this.tweet(status + ' ' + quoted_status_url.toString(), payload)
+    const url = 'https://twitter.com/i/statuses/' + quoting_status_id;
+    return this.tweet(status, { ...payload, attachment_url: url });
   }
 
   /**

--- a/src/v2/client.v2.write.ts
+++ b/src/v2/client.v2.write.ts
@@ -131,6 +131,14 @@ export default class TwitterApiv2ReadWrite extends TwitterApiv2ReadOnly {
   }
 
   /**
+   * Quote an existing Tweet on behalf of an authenticated user.
+   * https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets
+   */
+  public quote(status: string, quotedTweetId: string, payload: Partial<SendTweetV2Params> = {}) {
+    return this.tweet(status, { ...payload, quote_tweet_id: quotedTweetId });
+  }
+
+  /**
    * Post a series of tweets.
    * https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets
    */


### PR DESCRIPTION
Adds a `quote` method to the `TwitterApiv1ReadWrite` class that takes the same parameters as `tweet`, in addition to `quoting_status_id: string`. Calls `v1.singleTweet` to get the username of the author of the quoted tweet, uses that to generate the appropriate QT url and appends the url to the status. Then calls `.tweet` as normal.

Passes all tests.