### PR TITLE
doc: add code to extract bearer token

### DIFF
--- a/doc/auth.md
+++ b/doc/auth.md
@@ -234,6 +234,9 @@ app.get('/callback', (req, res) => {
       // Store {accessToken} somewhere, it will be valid until {expiresIn} is hit.
       // If you want to refresh your token later, store {refreshToken} (it is present if 'offline.access' has been given as scope)
 
+      // If you want to extract Bearer token for use later, you can extract it from {loggedClient}:
+      // const { bearerToken } = loggedClient
+
       // Example request
       const { data: userObject } = await loggedClient.v2.me();
     })
@@ -243,7 +246,7 @@ app.get('/callback', (req, res) => {
 
 ### Use your access token
 
-The `.loginWithOAuth2()` method already returns a logged client, but if you want to create an instance by yourself with an access token (for example to make a request from a saved access token), use it as a **Bearer token**.
+The `.loginWithOAuth2()` method already returns a logged client, but if you want to create an instance by yourself with an access token (for example to make a request from a saved access token), use it as a **Bearer token**
 
 ```ts
 const client = new TwitterApi('<YOUR-ACCESS-TOKEN>');


### PR DESCRIPTION
I was trying to log in using bearer token, but got stuck for a long long time. After some debugging, I found out that the bearer token is stored inside loggedClient. So I think some basic code might help people with few experience with Twitter's API.