### PR TITLE
Add media variants typings.

### DIFF
--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -25,6 +25,12 @@ export interface PlaybackCountV2 {
 
 export type OrganicMetricV2 = PlaybackCountV2 & { view_count: number };
 
+export interface MediaVariantsV2 {
+  bit_rate?: number;
+  content_type: 'video/mp4' | 'application/x-mpegURL' | string;
+  url: string
+}
+
 export interface MediaObjectV2 {
   media_key: string;
   type: 'video' | 'animated_gif' | 'photo' | string;
@@ -38,6 +44,7 @@ export interface MediaObjectV2 {
   organic_metrics?: OrganicMetricV2;
   promoted_metrics?: OrganicMetricV2;
   public_metrics?: { view_count: number };
+  variants?: MediaVariantsV2[];
 }
 
 export interface PollV2 {

--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -44,7 +44,7 @@ export type TTweetv2Expansion = 'attachments.poll_ids' | 'attachments.media_keys
   | 'author_id' | 'referenced_tweets.id' | 'in_reply_to_user_id'
   | 'geo.place_id' | 'entities.mentions.username' | 'referenced_tweets.id.author_id';
 export type TTweetv2MediaField = 'duration_ms' | 'height' | 'media_key' | 'preview_image_url' | 'type'
-  | 'url' | 'width' | 'public_metrics' | 'non_public_metrics' | 'organic_metrics' | 'alt_text';
+  | 'url' | 'width' | 'public_metrics' | 'non_public_metrics' | 'organic_metrics' | 'alt_text' | 'variants';
 export type TTweetv2PlaceField = 'contained_within' | 'country' | 'country_code' | 'full_name' | 'geo' | 'id' | 'name' | 'place_type';
 export type TTweetv2PollField = 'duration_minutes' | 'end_datetime' | 'id' | 'options' | 'voting_status';
 export type TTweetv2TweetField = 'attachments' | 'author_id' | 'context_annotations' | 'conversation_id'

--- a/test/tweet.v2.test.ts
+++ b/test/tweet.v2.test.ts
@@ -105,6 +105,11 @@ describe('Tweets endpoints for v2 API', () => {
     expect(tweet.data.text).to.equal('just setting up my twttr');
   }).timeout(60 * 1000);
 
+  it('.tweetWithMedia - Get a tweet with media variants', async () => {
+    const tweet = await client.v2.singleTweet('870042717589340160', { 'tweet.fields': ['attachments'], 'expansions': ['attachments.media_keys'], 'media.fields': ['variants'] });
+    expect(tweet.includes && tweet.includes.media && tweet.includes.media[0].variants && tweet.includes.media[0].variants[0].content_type).to.equal('video/mp4');
+  }).timeout(60 * 1000);
+
   it('.tweets - Fetch a bunch of tweets', async () => {
     const tweets = await client.v2.tweets(['20', '1257577057862610951'], {
       'tweet.fields': ['author_id', 'source'],


### PR DESCRIPTION
This adds typings for the `media.fields` entry `"variants"` that is missing, and also adds a new `MediaVariantsV2` type to the `MediaOvjectV2` object.  I also added a test to show that such a call works as expected.

```
✔ .tweetWithMedia - Get a tweet with media variants (200ms)
```