### PR TITLE
feat: get friends/followers ids V1

### DIFF
--- a/doc/v1.md
+++ b/doc/v1.md
@@ -39,6 +39,8 @@ For streaming API, see [Streaming part](./streaming.md).
 	* [Report user as spam](#Reportuserasspam)
 	* [List muted users (objects)](#Listmutedusersobjects)
 	* [List muted users (IDs)](#ListmutedusersIDs)
+  	* [Get Ids of followers of a user](#GetIdsoffollowersofauser)
+  	* [Get Ids of friends of a user](#GetIdsoffriendsofauser)
 	* [Get sizes of profile banner of a user](#Getsizesofprofilebannerofauser)
 	* [Get detailed relationship between two users](#Getdetailedrelationshipbetweentwousers)
 	* [Update relationship between you and other user](#Updaterelationshipbetweenyouandotheruser)
@@ -588,6 +590,56 @@ To access user IDs from the paginator, use `.ids` property.
 const mutedUsers = await client.v1.listMutedUserIds();
 console.log('First page of muted user ids:', mutedUsers.ids);
 console.log('Second page of muted user ids:', (await mutedUsers.next()).ids);
+```
+
+### <a name='GetIdsoffollowersofauser'></a>Get Ids of followers of a user
+
+Get ids of followers of the specified user (IDs only).
+Get to know how [paginators work here](./paginators.md).
+
+To access user IDs from the paginator, use `.ids` property.
+
+**Method**: `.userFollowerIds()`
+
+**Endpoint**: `followers/ids.json`
+
+**Right level**: `Read-only`
+
+**Arguments**:
+  - `options?: UserFollowerIdsV1Params`
+
+**Returns**: `UserFollowerIdsV1Paginator` (containing `string` items)
+
+**Example**
+```ts
+const followers = await client.v1.userFollowerIds({ screen_name: 'WSJ' });
+console.log('First page of follower ids of "WSJ" user:', followers.ids);
+console.log('Second page of follower ids of "WSJ" user:', (await followers.next()).ids);
+```
+
+### <a name='GetIdsoffriendsofauser'></a>Get Ids of friends of a user
+
+Get ids of friends of the specified user (IDs only).
+Get to know how [paginators work here](./paginators.md).
+
+To access user IDs from the paginator, use `.ids` property.
+
+**Method**: `.userFriendIds()`
+
+**Endpoint**: `friends/ids.json`
+
+**Right level**: `Read-only`
+
+**Arguments**:
+  - `options?: UserFriendsIdsV1Params`
+
+**Returns**: `UserFriendIdsV1Paginator` (containing `string` items)
+
+**Example**
+```ts
+const friends = await client.v1.userFriendIds({ screen_name: 'WSJ' });
+console.log('First page of friend ids of "WSJ" user:', friends.ids);
+console.log('Second page of friend ids of "WSJ" user:', (await friends.next()).ids);
 ```
 
 ### <a name='Getsizesofprofilebannerofauser'></a>Get sizes of profile banner of a user

--- a/src/paginators/followers.paginator.v1.ts
+++ b/src/paginators/followers.paginator.v1.ts
@@ -1,0 +1,32 @@
+import { CursoredV1Paginator } from './paginator.v1';
+import type { UserFollowerIdsV1Params, UserFollowerIdsV1Result, TwitterResponse } from '../types';
+
+export class UserFollowerIdsV1Paginator extends CursoredV1Paginator<UserFollowerIdsV1Result, UserFollowerIdsV1Params, string> {
+  protected _endpoint = 'followers/ids.json';
+  protected _maxResultsWhenFetchLast = 5000;
+
+  protected refreshInstanceFromResult(response: TwitterResponse<UserFollowerIdsV1Result>, isNextPage: true) {
+    const result = response.data;
+    this._rateLimit = response.rateLimit!;
+
+    if (isNextPage) {
+      this._realData.ids.push(...result.ids);
+      this._realData.next_cursor = result.next_cursor;
+    }
+  }
+
+  protected getPageLengthFromRequest(result: TwitterResponse<UserFollowerIdsV1Result>) {
+    return result.data.ids.length;
+  }
+
+  protected getItemArray() {
+    return this.ids;
+  }
+
+  /**
+   * Users IDs returned by paginator.
+   */
+  get ids() {
+    return this._realData.ids;
+  }
+}

--- a/src/paginators/friends.paginator.v1.ts
+++ b/src/paginators/friends.paginator.v1.ts
@@ -1,0 +1,32 @@
+import { CursoredV1Paginator } from './paginator.v1';
+import type { UserFriendsIdsV1Params, UserFriendIdsV1Result, TwitterResponse } from '../types';
+
+export class UserFriendIdsV1Paginator extends CursoredV1Paginator<UserFriendIdsV1Result, UserFriendsIdsV1Params, string> {
+  protected _endpoint = 'friends/ids.json';
+  protected _maxResultsWhenFetchLast = 5000;
+
+  protected refreshInstanceFromResult(response: TwitterResponse<UserFriendIdsV1Result>, isNextPage: true) {
+    const result = response.data;
+    this._rateLimit = response.rateLimit!;
+
+    if (isNextPage) {
+      this._realData.ids.push(...result.ids);
+      this._realData.next_cursor = result.next_cursor;
+    }
+  }
+
+  protected getPageLengthFromRequest(result: TwitterResponse<UserFriendIdsV1Result>) {
+    return result.data.ids.length;
+  }
+
+  protected getItemArray() {
+    return this.ids;
+  }
+
+  /**
+   * Users IDs returned by paginator.
+   */
+  get ids() {
+    return this._realData.ids;
+  }
+}

--- a/src/paginators/index.ts
+++ b/src/paginators/index.ts
@@ -7,3 +7,5 @@ export * from './user.paginator.v1';
 export * from './user.paginator.v2';
 export * from './list.paginator.v1';
 export * from './list.paginator.v2';
+export * from './friends.paginator.v1';
+export * from './followers.paginator.v1';

--- a/src/types/v1/user.v1.types.ts
+++ b/src/types/v1/user.v1.types.ts
@@ -54,6 +54,18 @@ export interface DoubleEndedIdCursorV1Params {
   cursor?: string;
 }
 
+export interface UserFriendsIdsV1Params extends DoubleEndedIdCursorV1Params {
+  screen_name?: string;
+  user_id?: string;
+  count?: number;
+}
+
+export interface UserFollowerIdsV1Params extends DoubleEndedIdCursorV1Params {
+  screen_name?: string;
+  user_id?: string;
+  count?: number;
+}
+
 export interface VerifyCredentialsV1Params {
   include_entities?: boolean;
   skip_status?: boolean;
@@ -173,6 +185,10 @@ export interface MuteUserListV1Result {
 
 // GET mutes/users/ids
 export type MuteUserIdsV1Result = DoubleEndedIdCursorV1Result;
+
+export type UserFollowerIdsV1Result = DoubleEndedIdCursorV1Result;
+
+export type UserFriendIdsV1Result = DoubleEndedIdCursorV1Result;
 
 // GET users/profile_banner
 export interface BannerSizeV1 {

--- a/src/v1/client.v1.read.ts
+++ b/src/v1/client.v1.read.ts
@@ -29,6 +29,10 @@ import {
   MuteUserListV1Params,
   MuteUserIdsV1Result,
   MuteUserIdsV1Params,
+  UserFollowerIdsV1Params,
+  UserFollowerIdsV1Result,
+  UserFriendsIdsV1Params,
+  UserFriendIdsV1Result,
   UserSearchV1Params,
   AccountSettingsV1,
   ProfileBannerSizeV1,
@@ -60,6 +64,8 @@ import {
 } from '../types';
 import { HomeTimelineV1Paginator, ListTimelineV1Paginator, MentionTimelineV1Paginator, UserFavoritesV1Paginator, UserTimelineV1Paginator } from '../paginators/tweet.paginator.v1';
 import { MuteUserIdsV1Paginator, MuteUserListV1Paginator } from '../paginators/mutes.paginator.v1';
+import { UserFollowerIdsV1Paginator } from '../paginators/followers.paginator.v1';
+import { UserFriendIdsV1Paginator } from '../paginators/friends.paginator.v1';
 import { FriendshipsIncomingV1Paginator, FriendshipsOutgoingV1Paginator, UserSearchV1Paginator } from '../paginators/user.paginator.v1';
 import { ListMembershipsV1Paginator, ListMembersV1Paginator, ListOwnershipsV1Paginator, ListSubscribersV1Paginator, ListSubscriptionsV1Paginator } from '../paginators/list.paginator.v1';
 import TweetStream from '../stream/TweetStream';
@@ -294,6 +300,44 @@ export default class TwitterApiv1ReadOnly extends TwitterApiSubClient {
     const initialRq = await this.get<MuteUserIdsV1Result>('mutes/users/ids.json', queryParams, { fullResponse: true });
 
     return new MuteUserIdsV1Paginator({
+      realData: initialRq.data,
+      rateLimit: initialRq.rateLimit!,
+      instance: this,
+      queryParams,
+    });
+  }
+
+  /**
+   * Returns an array of numeric user ids of followers of the specified user.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids
+   */
+   public async userFollowerIds(options: Partial<UserFollowerIdsV1Params> = {}) {
+    const queryParams: Partial<UserFollowerIdsV1Params> = {
+      stringify_ids: true,
+      ...options,
+    };
+    const initialRq = await this.get<UserFollowerIdsV1Result>('followers/ids.json', queryParams, { fullResponse: true });
+
+    return new UserFollowerIdsV1Paginator({
+      realData: initialRq.data,
+      rateLimit: initialRq.rateLimit!,
+      instance: this,
+      queryParams,
+    });
+  }
+
+  /**
+   * Returns an array of numeric user ids of friends of the specified user.
+   * https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids
+   */
+   public async userFriendIds(options: Partial<UserFriendsIdsV1Params> = {}) {
+    const queryParams: Partial<UserFriendsIdsV1Params> = {
+      stringify_ids: true,
+      ...options,
+    };
+    const initialRq = await this.get<UserFriendIdsV1Result>('friends/ids.json', queryParams, { fullResponse: true });
+
+    return new UserFriendIdsV1Paginator({
       realData: initialRq.data,
       rateLimit: initialRq.rateLimit!,
       instance: this,


### PR DESCRIPTION
Code to get the Ids of friends and followers of the specified user has been written.

Wrappers for the following endpoints have been written:
- https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids
- https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids