### PR TITLE
docs: make "single tweet" more descriptive

### DIFF
--- a/doc/v2.md
+++ b/doc/v2.md
@@ -29,7 +29,7 @@ This is a comprehensive guide of all methods available for the Twitter API v2 on
 	* [Reply to a tweet](#Replytoatweet)
 	* [Post a thread of tweets](#Postathreadoftweets)
 	* [Delete a tweet](#Deleteatweet)
-	* [Single tweet](#Singletweet)
+	* [Get a Single tweet](#Singletweet)
 	* [Lookup for tweets](#Lookupfortweets)
 	* [Get users that liked a specific tweet](#Getusersthatlikedaspecifictweet)
 	* [Like a tweet](#Likeatweet)
@@ -319,7 +319,7 @@ Delete a tweet that belongs to you.
 await client.v2.deleteTweet('20');
 ```
 
-### <a name='Singletweet'></a>Single tweet
+### <a name='Singletweet'></a>Get a Single tweet
 
 **Method**: `.singleTweet()`
 


### PR DESCRIPTION
Hi there!
Thanks for this amazing project 🙌

I have been reading the docs and, at first, I wasn't able to find how to get a single tweet by DM.

After some research I found that v1 docs have the "**Get a** Single Tweet" entry (https://github.com/PLhery/node-twitter-api-v2/blob/master/doc/v1.md#Getasingletweet) but the v2 don't. I think adding this might be helpful as "Single tweet" can be confusing (it could mean "Tweet a _single tweet_" or "Get a _single tweet_")

I usually use `ctrl+f` to find in docs and "Single tweet" is not something I would type. I think "Retrieve a tweet" or "Get a tweet" are more descriptive alternatives.


