### PR TITLE
Add missing `edit_history_tweet_ids` to TweetV2 interface

### DIFF
--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -191,6 +191,7 @@ export interface SendTweetV2Params {
 
 //// FINALLY, TweetV2
 export interface TweetV2 {
+  edit_history_tweet_ids: string[];
   id: string;
   text: string;
   created_at?: string;


### PR DESCRIPTION
See issue #383.