### PR TITLE
fix: Tweetv2SearchParams

### DIFF
--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -20,7 +20,7 @@ export interface TweetV2TimelineParams extends Partial<Tweetv2FieldsParams> {
 }
 
 export interface Tweetv2SearchParams extends TweetV2TimelineParams {
-  previous_token?: string;
+  pagination_token?: string;
   query: string;
   sort_order?: 'recency' | 'relevancy';
 }


### PR DESCRIPTION
### Describe the bug
I got this error 

> handled error ApiResponseError: Request failed with code 400 - Invalid Request: One or more parameters to your request was invalid. 
> (see https://api.twitter.com/2/problems/invalid-request) at RequestHandlerHelper.createResponseError 
> (/layers/google.nodejs.yarn/yarn_modules/node_modules/twitter-api-v2/dist/client-mixins/request-handler.helper.js:103:16) at RequestHandlerHelper.onResponseEndHandler 
> (/layers/google.nodejs.yarn/yarn_modules/node_modules/twitter-api-v2/dist/client-mixins/request-handler.helper.js:252:25) at Gunzip.emit (node:events:513:28) at Gunzip.emit 
> (node:domain:552:15) at endReadableNT (node:internal/streams/readable:1358:12) at processTicksAndRejections 
> (node:internal/process/task_queues:83:21)
>  { error: true, type: 'response', code: 400, headers: { date: 'Thu, 13 Oct 2022 05:41:22 UTC', perf: '7626143928', server: 'tsa_m', 'set-cookie': [ 'guest_id=v1%3A166563968241745511; Max-Age=34214400; Expires=Mon, 13 Nov 2023 05:41:22 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None' ], 'api-version': '2.53', 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-cache, no-store, max-age=0', 'content-length': '328', 'x-access-level': 'read', 'x-frame-options': 'SAMEORIGIN', 'content-encoding': 'gzip', 'x-transaction-id': '21ef1698d1cfe960', 'x-xss-protection': '0', 'x-rate-limit-limit': '450', 'x-rate-limit-reset': '1665640470', 'content-disposition': 'attachment; filename=json.json', 'x-content-type-options': 'nosniff', 'x-rate-limit-remaining': '447', 'strict-transport-security': 'max-age=631138519', 'x-response-time': '111', 'x-connection-hash': 'e45d10451db437e09749a5b0f06036f9f1829f86c437b3fe7095326a5273bc21', connection: 'close' }, rateLimit: { limit: 450, remaining: 447, reset: 1665640470 }, data: { errors: [ [Object] ], title: 'Invalid Request', detail: 'One or more parameters to your request was invalid.', type: 'https://api.twitter.com/2/problems/invalid-request' }, errors: [ { parameters: [Object], message: 'The query parameter [previous_token] is not one of [query,start_time,end_time,since_id,until_id,max_results,next_token,pagination_token,sort_order,expansions,tweet.fields,media.fields,poll.fields,place.fields,user.fields]' } ] }

Please check this sentence.
  **'The query parameter [previous_token] is not one of [query,start_time,end_time,since_id,until_id,max_results,next_token,pagination_token,sort_order,expansions,tweet.fields,media.fields,poll.fields,place.fields,user.fields]'**
I think `previous_token` should be  `pagination_token` in the `interface Tweetv2SearchParams`.

### Version
Node.js version: v16.14.0
Lib version: "twitter-api-v2": "^1.12.7"
OS (especially if you use Windows): macOS 11.3