### PR TITLE
fix: ReceivedMessageCreateDataV1

### DIFF
--- a/src/types/v1/dm.v1.types.ts
+++ b/src/types/v1/dm.v1.types.ts
@@ -115,7 +115,7 @@ export interface ReceivedMessageCreateDataV1 {
   text: string;
   entities: TweetEntitiesV1;
   quick_reply_response?: { type: 'options', metadata?: string };
-  attachment?: MediaEntityV1;
+  attachment?: { type: 'media', media: MediaEntityV1 };
   quick_reply?: MessageCreateQuickReplyV1;
   ctas?: MessageCreateCtaV1[];
 }

--- a/src/types/v1/entities.v1.types.ts
+++ b/src/types/v1/entities.v1.types.ts
@@ -30,23 +30,26 @@ export interface UrlEntityV1 {
 }
 
 export interface MediaEntityV1 {
-  display_url: string;
-  expanded_url: string;
-  url: string;
-  id: number;
-  id_str: string;
-  indices: [number, number];
-  media_url: string;
-  media_url_https: string;
-  sizes: MediaSizesV1;
-  source_status_id: number;
-  source_status_id_str: string;
-  source_user_id: number;
-  source_user_id_str: string;
-  type: 'photo' | 'video' | 'animated_gif';
-  video_info?: MediaVideoInfoV1;
-  additional_media_info?: AdditionalMediaInfoV1;
-  ext_alt_text?: string;
+  type: 'media',
+  media: {
+    display_url: string;
+    expanded_url: string;
+    url: string;
+    id: number;
+    id_str: string;
+    indices: [number, number];
+    media_url: string;
+    media_url_https: string;
+    sizes: MediaSizesV1;
+    source_status_id: number;
+    source_status_id_str: string;
+    source_user_id: number;
+    source_user_id_str: string;
+    type: 'photo' | 'video' | 'animated_gif';
+    video_info?: MediaVideoInfoV1;
+    additional_media_info?: AdditionalMediaInfoV1;
+    ext_alt_text?: string;
+  }
 }
 
 export interface MediaVideoInfoV1 {

--- a/src/types/v1/entities.v1.types.ts
+++ b/src/types/v1/entities.v1.types.ts
@@ -30,26 +30,23 @@ export interface UrlEntityV1 {
 }
 
 export interface MediaEntityV1 {
-  type: 'media',
-  media: {
-    display_url: string;
-    expanded_url: string;
-    url: string;
-    id: number;
-    id_str: string;
-    indices: [number, number];
-    media_url: string;
-    media_url_https: string;
-    sizes: MediaSizesV1;
-    source_status_id: number;
-    source_status_id_str: string;
-    source_user_id: number;
-    source_user_id_str: string;
-    type: 'photo' | 'video' | 'animated_gif';
-    video_info?: MediaVideoInfoV1;
-    additional_media_info?: AdditionalMediaInfoV1;
-    ext_alt_text?: string;
-  }
+  display_url: string;
+  expanded_url: string;
+  url: string;
+  id: number;
+  id_str: string;
+  indices: [number, number];
+  media_url: string;
+  media_url_https: string;
+  sizes: MediaSizesV1;
+  source_status_id: number;
+  source_status_id_str: string;
+  source_user_id: number;
+  source_user_id_str: string;
+  type: 'photo' | 'video' | 'animated_gif';
+  video_info?: MediaVideoInfoV1;
+  additional_media_info?: AdditionalMediaInfoV1;
+  ext_alt_text?: string;
 }
 
 export interface MediaVideoInfoV1 {

--- a/src/v1/client.v1.ts
+++ b/src/v1/client.v1.ts
@@ -258,7 +258,7 @@ export class TwitterApiv1 extends TwitterApiv1ReadWrite {
         throw new Error('The given direct message doesn\'t contain any attachment');
       }
 
-      urlOrDm = attachment.media_url_https;
+      urlOrDm = attachment.media.media_url_https;
     }
 
     const data = await this.get<Buffer>(urlOrDm, undefined, { forceParseMode: 'buffer', prefix: '' });


### PR DESCRIPTION
## the changes this PR

Fixes errors due to differences between MediaEntityV1 and the actual response type

## why it should be merged

When run as per [DownloadamediaattachedinaDM](https://github.com/PLhery/node-twitter-api-v2/blob/master/doc/v1.md#DownloadamediaattachedinaDM)
```js
const eventsPaginator = await client.v1.listDmEvents();

for await (const event of eventsPaginator) {
  if (
    event.type === EDirectMessageEventTypeV1.Create &&
    event[EDirectMessageEventTypeV1.Create].message_data.attachment
  ) {
    console.dir(event, { depth: null }); //log
    const image = await client.v1.downloadDmImage(event);
  }
}
```

The actual response of the event (DirectMessageCreateV1) was as follows.

```js
{
  type: 'message_create',
  id: '**********',
  created_timestamp: '1668707634771',
  message_create: {
    target: { recipient_id: '**********' },
    sender_id: '**********',
    message_data: {
      text: 'テスト https://t.co/**********',
      entities: {
        hashtags: [],
        symbols: [],
        user_mentions: [],
        urls: [
          {
            url: 'https://t.co/**********',
            expanded_url: 'https://twitter.com/messages/media/**********',
            display_url: 'pic.twitter.com/**********',
            indices: [ 4, 27 ]
          }
        ]
      },
      attachment: {
        type: 'media',
        media: {
          id: **********,
          id_str: '**********',
          indices: [ 4, 27 ],
          media_url: 'https://ton.twitter.com/1.1/ton/data/dm/**********/**********.jpg',
          media_url_https: 'https://ton.twitter.com/1.1/ton/data/dm/**********/**********/***.jpg',
          url: 'https://t.co/**********',
          display_url: 'pic.twitter.com/**********',
          expanded_url: 'https://twitter.com/messages/media/**********',
          type: 'photo',
          sizes: {
            thumb: { w: 150, h: 150, resize: 'crop' },
            small: { w: 680, h: 680, resize: 'fit' },
            medium: { w: 1080, h: 1080, resize: 'fit' },
            large: { w: 1080, h: 1080, resize: 'fit' }
          }
        }
      }
    }
  }
}
```

※attachment is the type of MediaEntityV1
So, `urlOrDm = attachment.media_url_https` in downloadDmImage becomes undefined

## note
Tried with 3 types: photo, video, animated_gif
Please let me know if I missed something