### PR TITLE
Check if headers content-type is already set to avoid overwrite of pr…

### DIFF
--- a/src/client-mixins/request-param.helper.ts
+++ b/src/client-mixins/request-param.helper.ts
@@ -79,11 +79,15 @@ export class RequestParamHelpers {
     }
 
     if (mode === 'json') {
-      headers['content-type'] = 'application/json;charset=UTF-8';
+      if (!headers['content-type']) {
+        headers['content-type'] = 'application/json;charset=UTF-8';
+      }
       return JSON.stringify(body);
     }
     else if (mode === 'url') {
-      headers['content-type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
+      if (!headers['content-type']) {
+        headers['content-type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
+      }
 
       if (Object.keys(body).length) {
         return new URLSearchParams(body)

--- a/src/client-mixins/request-param.helper.ts
+++ b/src/client-mixins/request-param.helper.ts
@@ -107,8 +107,10 @@ export class RequestParamHelpers {
         form.append(parameter, body[parameter]);
       }
 
-      const formHeaders = form.getHeaders();
-      headers['content-type'] = formHeaders['content-type'];
+      if (!headers['content-type']) {
+        const formHeaders = form.getHeaders();
+        headers['content-type'] = formHeaders['content-type'];
+      }
 
       return form.getBuffer();
     }


### PR DESCRIPTION
…eviously setted content-type in constructBodyParams method

When sending [web conversions API](https://developer.twitter.com/en/docs/twitter-ads-api/measurement/web-conversions/api-reference/conversions) to twitter using the `post` method of the library Twitter returns a 500 http error.

According to [this twitter post](https://twittercommunity.com/t/website-conversion-api/178989) to avoid the error the header 'content-type' : 'application/json;charset=UTF-8' must be used. 

Even if the headers 'content-type' is setted in the `post()` method `args` field, the 'content-type' is then overwritten by the `constructBodyParams()` method. The solution could be using the `forceBodyMode :'json'` in the `post()` method but in doing so the library converts the entire body to a string by using `JSON.stringify()` and the "stringed" body is not valid and the Twitter API rejects it.

The solution is to accept the forced content-type from the `post` `args` field and not overwrite it.
