### PR TITLE
Fix V2 search error with query key in options

### DIFF
--- a/src/v2/client.v2.read.ts
+++ b/src/v2/client.v2.read.ts
@@ -101,13 +101,12 @@ export default class TwitterApiv2ReadOnly extends TwitterApiSubClient {
    * The recent search endpoint returns Tweets from the last seven days that match a search query.
    * https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-recent
    */
-  public async search(options: Partial<Tweetv2SearchParams>): Promise<TweetSearchRecentV2Paginator>;
-  public async search(query: string, options?: Partial<Tweetv2SearchParams>): Promise<TweetSearchRecentV2Paginator>;
-  public async search(queryOrOptions: string | Partial<Tweetv2SearchParams>, options: Partial<Tweetv2SearchParams> = {}) {
-    const query = typeof queryOrOptions === 'string' ? queryOrOptions : undefined;
-    const realOptions = typeof queryOrOptions === 'object' && queryOrOptions !== null ? queryOrOptions : options;
-
-    const queryParams = { ...realOptions, query };
+  public async search(options: Tweetv2SearchParams): Promise<TweetSearchRecentV2Paginator>;
+  public async search(query: string, options?: Partial<Tweetv2SearchParams>): Promise<TweetSearchRecentV2Paginator>
+  public async search(queryOrOptions: string | Tweetv2SearchParams, options: Partial<Tweetv2SearchParams> = {}) {
+    const queryParams = typeof queryOrOptions === 'string' ?
+      { ...options, query: queryOrOptions } :
+      { ...queryOrOptions };
     const initialRq = await this.get<Tweetv2SearchResult>('tweets/search/recent', queryParams, { fullResponse: true });
 
     return new TweetSearchRecentV2Paginator({

--- a/test/tweet.v2.test.ts
+++ b/test/tweet.v2.test.ts
@@ -38,29 +38,33 @@ describe('Tweets endpoints for v2 API', () => {
   }).timeout(60 * 1000);
 
   it('.search - Search and fetch tweets using tweet searcher and consume 200 tweets', async () => {
-    const nodeJs = await client.v2.search('nodeJS');
+    // Using string for query
+    const response1 = await client.v2.search('nodeJS');
+    // Using object with query key
+    const response2 = await client.v2.search({ query: 'nodeJS' });
 
-    const originalLength = nodeJs.tweets.length;
-    expect(nodeJs.tweets.length).to.be.greaterThan(0);
+    for (const response of [response1, response2]) {
+      const originalLength = response.tweets.length;
+      expect(response.tweets.length).to.be.greaterThan(0);
 
-    await nodeJs.fetchNext();
-    expect(nodeJs.tweets.length).to.be.greaterThan(originalLength);
+      await response.fetchNext();
+      expect(response.tweets.length).to.be.greaterThan(originalLength);
 
-    // Test if iterator correctly fetch tweets (silent)
-    let i = 0;
-    const ids = [];
+      // Test if iterator correctly fetch tweets (silent)
+      let i = 0;
+      const ids = [];
 
-    for await (const tweet of nodeJs) {
-      ids.push(tweet.id);
-      if (i > 200) {
-        break;
+      for await (const tweet of response) {
+        ids.push(tweet.id);
+        if (i > 200) {
+          break;
+        }
+
+        i++;
       }
-
-      i++;
+      // Check for duplicates
+      expect(ids).to.have.length(new Set(ids).size);
     }
-
-    // Check for duplicates
-    expect(ids).to.have.length(new Set(ids).size);
   }).timeout(60 * 1000);
 
   it('.userTimeline/.userMentionTimeline - Fetch user & mention timeline and consume 150 tweets', async () => {


### PR DESCRIPTION
Issue: #430 

- Simplifies the logic of getting the query and options from the overload params, making it explicit when `query` is overridden and when it's not.

- Removes `Partial` from the type of `options` when it's the first parameter. The results in a type error when you provide a lone options object without a `query` key. For example: `client.v2.search({ max_results: 1 })` is a type error now. However, the type error is long and hard to read. I'll restate my suggestion from the issue of just reverting to the original API which was clearer, though that would be a breaking change now.

- Adds an additional test scenario for calling search with only an options object. This regrettably adds an additional 1.5 seconds to the runtime.