### PR TITLE
Added verified_type to user schema

### DIFF
--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -55,7 +55,7 @@ export type TTweetv2TweetField = 'attachments' | 'author_id' | 'context_annotati
   | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld';
 export type TTweetv2UserField = 'created_at' | 'description' | 'entities' | 'id' | 'location'
   | 'name' | 'pinned_tweet_id' | 'profile_image_url' | 'protected' | 'public_metrics'
-  | 'url' | 'username' | 'verified' | 'withheld';
+  | 'url' | 'username' | 'verified' | 'verified_type' | 'withheld';
 
 export interface Tweetv2FieldsParams {
   expansions: TypeOrArrayOf<TTweetv2Expansion> | string;

--- a/src/types/v2/user.v2.types.ts
+++ b/src/types/v2/user.v2.types.ts
@@ -98,6 +98,7 @@ export interface UserV2 {
   url?: string;
   description?: string;
   verified?: boolean;
+  verified_type?: "none" | "blue" | "business" | "government";
   entities?: {
     url?: { urls: UrlEntity[] };
     description: {


### PR DESCRIPTION
> [December 21, 2022](https://developer.twitter.com/en/updates/changelog)
> Twitter API v2
> 
> Today, we are adding a verified_type user field to the Twitter API v2 that indicates the type of verification a user account has (blue, business, government or none) .