### PR TITLE
[documentation] Rewrite the sample code using v2.tweet() instead of v1.tweet() because we unable to use v1.tweet() with free plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const readOnlyClient = twitterClient.readOnly;
 
 // Play with the built in methods
 const user = await readOnlyClient.v2.userByUsername('plhery');
-await twitterClient.v1.tweet('Hello, this is a test.');
+await twitterClient.v2.tweet('Hello, this is a test.');
 // You can upload media easily!
 await twitterClient.v1.uploadMedia('./big-buck-bunny.mp4');
 ```

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -160,7 +160,10 @@ const mediaIds = await Promise.all([
 ]);
 
 // mediaIds is a string[], can be given to .tweet
-await client.v1.tweet('My tweet text with two images!', { media_ids: mediaIds });
+await client.v2.tweet({
+  text: 'My tweet text with two images!',
+  media: { media_ids: mediaIds }
+});
 ```
 
 ### Reply to a tweet with a video that have subtitles

--- a/doc/rate-limiting.md
+++ b/doc/rate-limiting.md
@@ -47,7 +47,7 @@ import { ApiResponseError } from 'twitter-api-v2';
 
 try {
   // Get a single tweet
-  await client.v1.tweet('20');
+  await client.v2.tweet('20');
 } catch (error) {
   if (error instanceof ApiResponseError && error.rateLimitError && error.rateLimit) {
     console.log(`You just hit the rate limit! Limit for this endpoint is ${error.rateLimit.limit} requests!`);
@@ -85,7 +85,7 @@ async function autoRetryOnRateLimitError<T>(callback: () => T | Promise<T>) {
 }
 
 // Then use it...
-await autoRetryOnRateLimitError(() => client.v1.tweet('20'));
+await autoRetryOnRateLimitError(() => client.v2.tweet('20'));
 ```
 
 ## Special case of paginators


### PR DESCRIPTION
Thanks for the useful repository!!!

I think many users, including myself, would be on the free plan. Currently, users on the free plan do not have access to the v1 API endpoint. Therefore, in order to encourage more users to take advantage of this repository, I have rewritten the samples using v2.

In particular, the modification of `doc/examples.md` is important; simply rewriting v1 to v2 will not work. examples of working code is presented below (the former is used in this PR, but please let me know if you prefer the latter)
```
await client.v2.tweet({
  text: 'My tweet text with two images!',
  media: { media_ids: mediaIds }
});
```
```
await client.v2.tweet('My tweet text with two images!', 
{
  media: { media_ids: mediaIds }
});
```

Note: Similar updates may be needed for functions other than tweet(), but this PR focuses on the tweet() function only.