### PR TITLE
feat: add connection_status user field

### DIFF
--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -55,7 +55,7 @@ export type TTweetv2TweetField = 'attachments' | 'author_id' | 'context_annotati
   | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld';
 export type TTweetv2UserField = 'created_at' | 'description' | 'entities' | 'id' | 'location'
   | 'name' | 'pinned_tweet_id' | 'profile_image_url' | 'protected' | 'public_metrics'
-  | 'url' | 'username' | 'verified' | 'verified_type' | 'withheld';
+  | 'url' | 'username' | 'verified' | 'verified_type' | 'withheld' | 'connection_status';
 
 export interface Tweetv2FieldsParams {
   expansions: TypeOrArrayOf<TTweetv2Expansion> | string;

--- a/src/types/v2/user.v2.types.ts
+++ b/src/types/v2/user.v2.types.ts
@@ -114,6 +114,7 @@ export interface UserV2 {
     following_count?: number;
     tweet_count?: number;
     listed_count?: number;
-  },
+  }
   pinned_tweet_id?: string;
+  connection_status?: string[];
 }


### PR DESCRIPTION
https://devcommunity.x.com/t/announcing-connection-status-field-in-the-user-object-in-the-x-api-v2/212588