### PR TITLE
Add canceled and ended space state

### DIFF
--- a/src/types/v2/spaces.v2.types.ts
+++ b/src/types/v2/spaces.v2.types.ts
@@ -13,7 +13,7 @@ export type TSpaceV2Expansion = 'invited_user_ids' | 'speaker_ids' | 'creator_id
 export type TSpaceV2SpaceField = 'host_ids' | 'created_at' | 'creator_id' | 'id' | 'lang'
   | 'invited_user_ids' | 'participant_count' | 'speaker_ids' | 'started_at' | 'state' | 'title'
   | 'updated_at' | 'scheduled_start' | 'is_ticketed' | 'topic_ids' | 'ended_at' | 'subscriber_count';
-export type TSpaceV2State = 'live' | 'scheduled';
+export type TSpaceV2State = 'canceled' | 'ended' | 'live' | 'scheduled';
 
 // - Requests -
 


### PR DESCRIPTION
Although not mentioned in the docs, the `state` attribute on a space can also be `canceled` (e.g. 1OdKrjgmNkeKX) and `ended` (once the space ends, e.g. 1dRJZEXDRQAGB; a recording may or may not be available but that's only returned by the unofficial periscope api, not the official spaces api).