### PR TITLE
Type support for Tweets with more than 280 characters

### DIFF
--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -165,6 +165,13 @@ export interface TweetOrganicMetricsV2 {
 
 export type TweetPromotedMetricsV2 = TweetOrganicMetricsV2;
 
+export interface NoteTweetV2 {
+  text: string;
+  entities?: NoteTweetEntitiesV2;
+}
+
+export type NoteTweetEntitiesV2 = Omit<TweetEntitiesV2, 'annotations'>;
+
 export type TTweetReplySettingsV2 = 'mentionedUsers' | 'following' | 'everyone';
 
 export interface SendTweetV2Params {
@@ -213,7 +220,7 @@ export interface TweetV2 {
   lang?: string;
   reply_settings?: 'everyone' | 'mentionedUsers' | 'following';
   source?: string;
-  note_tweet?: { text: string, entities?: TweetEntitiesV2 };
+  note_tweet?: NoteTweetV2;
 }
 
 export interface ApiV2Includes {

--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -213,6 +213,7 @@ export interface TweetV2 {
   lang?: string;
   reply_settings?: 'everyone' | 'mentionedUsers' | 'following';
   source?: string;
+  note_tweet?: { text: string, entities?: TweetEntitiesV2 };
 }
 
 export interface ApiV2Includes {

--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -52,7 +52,7 @@ export type TTweetv2PollField = 'duration_minutes' | 'end_datetime' | 'id' | 'op
 export type TTweetv2TweetField = 'attachments' | 'author_id' | 'context_annotations' | 'conversation_id'
   | 'created_at' | 'entities' | 'geo' | 'id' | 'in_reply_to_user_id' | 'lang'
   | 'public_metrics' | 'non_public_metrics' | 'promoted_metrics' | 'organic_metrics' | 'edit_controls'
-  | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld' | 'note_text';
+  | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld' | 'note_tweet';
 export type TTweetv2UserField = 'created_at' | 'description' | 'entities' | 'id' | 'location'
   | 'name' | 'pinned_tweet_id' | 'profile_image_url' | 'protected' | 'public_metrics'
   | 'url' | 'username' | 'verified' | 'verified_type' | 'withheld' | 'connection_status';

--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -52,7 +52,7 @@ export type TTweetv2PollField = 'duration_minutes' | 'end_datetime' | 'id' | 'op
 export type TTweetv2TweetField = 'attachments' | 'author_id' | 'context_annotations' | 'conversation_id'
   | 'created_at' | 'entities' | 'geo' | 'id' | 'in_reply_to_user_id' | 'lang'
   | 'public_metrics' | 'non_public_metrics' | 'promoted_metrics' | 'organic_metrics' | 'edit_controls'
-  | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld';
+  | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld' | 'note_text';
 export type TTweetv2UserField = 'created_at' | 'description' | 'entities' | 'id' | 'location'
   | 'name' | 'pinned_tweet_id' | 'profile_image_url' | 'protected' | 'public_metrics'
   | 'url' | 'username' | 'verified' | 'verified_type' | 'withheld' | 'connection_status';


### PR DESCRIPTION
extended `TweetV2` and `TTweetv2TweetField` to support `note_tweet`. 

API Docs: https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets
<img width="734" alt="image" src="https://github.com/PLhery/node-twitter-api-v2/assets/39413655/c0cd96a2-8d0a-4b14-92cf-2c9ac1fa132e">
