### PR TITLE
Limit media_ids count from 1 to 4

### DIFF
--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -182,7 +182,11 @@ export interface SendTweetV2Params {
     place_id: string;
   };
   media?: {
-    media_ids?: string[];
+    media_ids?:
+      | [string]
+      | [string, string]
+      | [string, string, string]
+      | [string, string, string, string];
     tagged_user_ids?: string[];
   };
   poll?: {


### PR DESCRIPTION
Thanks for the useful repository!!

I am proposing this PR to address the following issues:

An error occurs when media_ids is an empty array `message: $.media.media_ids: there must be a minimum of 1 item in the array`.
An error occurs when media_ids is an array containing 5 or more items `message: $.media.media_ids: there must be a maximum of 4 items in the array`.
