### PR TITLE
fix: type definition for TweetRetweetedOrLikedByV2Params

### DIFF
--- a/src/types/v2/user.v2.types.ts
+++ b/src/types/v2/user.v2.types.ts
@@ -30,7 +30,7 @@ export interface UserV2TimelineParams {
   pagination_token?: string;
 }
 
-export interface TweetRetweetedOrLikedByV2Params extends Partial<UsersV2Params> {
+export interface TweetRetweetedOrLikedByV2Params extends UserV2TimelineParams {
   asPaginator?: boolean;
 }
 


### PR DESCRIPTION
X API endpoints for:
- https://developer.x.com/en/docs/x-api/tweets/retweets/api-reference/get-tweets-id-retweeted_by
- https://developer.x.com/en/docs/x-api/tweets/likes/api-reference/get-tweets-id-liking_users
has `max_results` and `pagination_token` fields but they're not typed correctly in the implementation.