### PR TITLE
fix: add and correct field names

### DIFF
--- a/src/types/entities.types.ts
+++ b/src/types/entities.types.ts
@@ -11,11 +11,11 @@ export interface UrlEntity extends Entity {
 }
 
 export interface HashtagEntity extends Entity {
-  hashtag: string;
+  tag: string;
 }
 
 export interface CashtagEntity extends Entity {
-  cashtag: string;
+  tag: string;
 }
 
 export interface MentionEntity extends Entity {

--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -106,6 +106,7 @@ export interface TweetEntityUrlV2 {
   description?: string;
   status?: string;
   images?: TweetEntityUrlImageV2[];
+  media_key?: string;
 }
 
 export interface TweetEntityUrlImageV2 {

--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -52,7 +52,7 @@ export type TTweetv2PollField = 'duration_minutes' | 'end_datetime' | 'id' | 'op
 export type TTweetv2TweetField = 'attachments' | 'author_id' | 'context_annotations' | 'conversation_id'
   | 'created_at' | 'entities' | 'geo' | 'id' | 'in_reply_to_user_id' | 'lang'
   | 'public_metrics' | 'non_public_metrics' | 'promoted_metrics' | 'organic_metrics' | 'edit_controls'
-  | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld' | 'note_tweet';
+  | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld' | 'note_tweet' | 'edit_history_tweet_ids';
 export type TTweetv2UserField = 'created_at' | 'description' | 'entities' | 'id' | 'location'
   | 'name' | 'pinned_tweet_id' | 'profile_image_url' | 'protected' | 'public_metrics'
   | 'url' | 'username' | 'verified' | 'verified_type' | 'withheld' | 'connection_status' | 'most_recent_tweet_id';

--- a/src/types/v2/user.v2.types.ts
+++ b/src/types/v2/user.v2.types.ts
@@ -115,6 +115,7 @@ export interface UserV2 {
     tweet_count?: number;
     listed_count?: number;
     like_count?: number;
+    media_count?: number;
   }
   pinned_tweet_id?: string;
   connection_status?: string[];


### PR DESCRIPTION
- Correct misnamed fields in `HashtagEntity` and `CashtagEntity` ([reference](https://developer.x.com/en/docs/x-api/data-dictionary/object-model/user)).
- Add `media_count` to `UserV2`, as it is included in the API response.
- Add `'edit_history_tweet_ids'` to `TTweetv2TweetField` ([reference](https://developer.x.com/en/docs/x-api/data-dictionary/object-model/tweet)).
- Add `media_key` to `TweetEntityUrlV2` ([reference](https://developer.x.com/en/docs/x-api/data-dictionary/object-model/tweet) - Sample Response).