### PR TITLE
fix(upload-media): media type input type

### DIFF
--- a/src/v2/client.v2.write.ts
+++ b/src/v2/client.v2.write.ts
@@ -134,7 +134,7 @@ export default class TwitterApiv2ReadWrite extends TwitterApiv2ReadOnly {
    */
   public async uploadMedia(
     media: Buffer,
-    options: { media_type: EUploadMimeType; media_category?: MediaV2MediaCategory },
+    options: { media_type: `${EUploadMimeType}` | EUploadMimeType; media_category?: MediaV2MediaCategory },
     chunkSize: number = 1024 * 1024
   ): Promise<string> {
     let media_category = options.media_category;


### PR DESCRIPTION
- Allows for a user to retrieve the `contentType` from a url (`www.some-url.com.image.png`), and upload media without using enum.

Previous PR got merged in quicker than what I was expecting.