### PR TITLE
V2 Media Metadata & Updated V2 Docs

### DIFF
--- a/doc/v2.md
+++ b/doc/v2.md
@@ -62,6 +62,9 @@ This is a comprehensive guide of all methods available for the Twitter API v2 on
     - [Mute someone](#mute-someone)
     - [Unmute someone](#unmute-someone)
     - [Get users that are muted by you](#get-users-that-are-muted-by-you)
+  - [Upload medias](#upload-medias)
+    - [Upload media](#upload-media)
+    - [Upload media metadata](#upload-media-metadata)
   - [Usage](#usage)
     - [Get usage](#get-usage)
   - [Lists](#lists)
@@ -997,6 +1000,51 @@ const mutedPaginator = await client.v2.userMutingUsers('14');
 for await (const mutedUser of mutedPaginator) {
   console.log(`You are muting @${mutedUser.username}.`);
 }
+```
+
+## Upload medias
+
+### Upload media
+
+**Method**: `.uploadMedia()`
+
+**Endpoint**: `media/upload`
+
+**Right level**: `Read-write`
+
+**Arguments**:
+  - `media: Buffer`: Media buffer
+  - `options: MediaV2UploadParams`
+    - `options.media_type`: EUploadMimeType (the mimetype of the media)
+    - `options.media_category?`: MediaV2MediaCategory (the category of the media)
+    - `options.chunkSize`: Chunk size
+
+**Returns**: `string`: Media ID
+
+**Example**
+```ts
+const mediaId = await client.v2.uploadMedia(Buffer.from('imgae.png'), { media_type: 'image/png' });
+const newTweet = await client.v1.tweet('Hello!', { media_ids: mediaId });
+```
+
+### Upload media metadata
+
+**Method**: `.createMediaMetadata()`
+
+**Endpoint**: `media/metadata`
+
+**Right level**: `Read-write`
+
+**Arguments**:
+  - `mediaId: string`
+  - `metadata: MediaV2MetadataCreateParams`
+    - `metadata.alt_text`: `{ text: string }` the alt text of the media
+
+**Returns**: `MediaV2MetadataCreateResult`
+
+**Example**
+```ts
+await client.v2.createMediaMetadata(mediaId, { alt_text: { text: 'Hello, world!' } });
 ```
 
 ### Get usage

--- a/src/types/v2/media.v2.types.ts
+++ b/src/types/v2/media.v2.types.ts
@@ -37,3 +37,16 @@ export interface MediaV2UploadResponse {
     processing_info?: MediaV2ProcessingInfo;
   };
 }
+
+export interface MediaV2MetadataCreateParams {
+  alt_text?: { text: string };
+}
+
+export interface MediaV2MetadataCreateResult {
+  data: {
+    id: string;
+    associated_metadata: {
+      alt_text: { text: string };
+    };
+  };
+}

--- a/src/v2/client.v2.write.ts
+++ b/src/v2/client.v2.write.ts
@@ -24,7 +24,7 @@ import type {
 } from '../types';
 import TwitterApiv2LabsReadWrite from '../v2-labs/client.v2.labs.write';
 import { CreateDMConversationParams, PostDMInConversationParams, PostDMInConversationResult } from '../types/v2/dm.v2.types';
-import { MediaV2MediaCategory, MediaV2UploadAppendParams, MediaV2UploadFinalizeParams, MediaV2UploadInitParams, MediaV2UploadResponse } from '../types/v2/media.v2.types';
+import { MediaV2MediaCategory, MediaV2MetadataCreateParams, MediaV2MetadataCreateResult, MediaV2UploadAppendParams, MediaV2UploadFinalizeParams, MediaV2UploadInitParams, MediaV2UploadResponse } from '../types/v2/media.v2.types';
 
 /**
  * Base Twitter v2 client with read/write rights.
@@ -213,6 +213,15 @@ export default class TwitterApiv2ReadWrite extends TwitterApiv2ReadOnly {
         }
       }
     }
+  }
+
+  /**
+   * Creates the metadata for media to be uploaded.
+   * This feature is currently only supported for images and GIFs.
+   * https://docs.x.com/x-api/media/metadata-create
+   */
+  public createMediaMetadata(mediaId: string, metadata: Partial<MediaV2MetadataCreateParams>) {
+    return this.post<MediaV2MetadataCreateResult>('/media/metadata', { media_id: mediaId, ...metadata });
   }
 
   /**


### PR DESCRIPTION
Added media metadata functionality from this endpoint https://docs.x.com/x-api/media/media-upload (only supports `alt_text` which I think is what people would want anyways) so we can migrate from the `v1` media endpoints as they're getting deprecated on March 31st

https://devcommunity.x.com/t/deprecating-the-v1-1-media-upload-endpoints/238196

<img width="798" alt="image" src="https://github.com/user-attachments/assets/f4f751ea-83c9-42ca-a7ee-e47d2b753ba6" />

Also updated the `v2` docs to include `uploadMedia` and the new `createMediaMetadata`

Related to https://github.com/PLhery/node-twitter-api-v2/issues/573 (missing metadata endpoint) and https://github.com/PLhery/node-twitter-api-v2/issues/569 (missing documentation)