### PR TITLE
Media V2 Metadata: don't spread metadata params

### DIFF
--- a/src/v2/client.v2.write.ts
+++ b/src/v2/client.v2.write.ts
@@ -221,7 +221,7 @@ export default class TwitterApiv2ReadWrite extends TwitterApiv2ReadOnly {
    * https://docs.x.com/x-api/media/metadata-create
    */
   public createMediaMetadata(mediaId: string, metadata: Partial<MediaV2MetadataCreateParams>) {
-    return this.post<MediaV2MetadataCreateResult>('media/metadata', { id: mediaId, ...metadata });
+    return this.post<MediaV2MetadataCreateResult>('media/metadata', { id: mediaId, metadata });
   }
 
   /**


### PR DESCRIPTION
Issue was I was spreading the metadata params

Not working but should: `await client.v2.createMediaMetadata(mediaId, { alt_text: { text: 'Hello, world!' } });`
Working but shouldn't: `await client.v2.createMediaMetadata(mediaId, { metadata: {alt_text: { text: 'Hello, world!' } } });`

Issue was I had written based of our v1 metadata endpoint but the v1 doesn't take in `metadata` https://developer.x.com/en/docs/x-api/v1/media/upload-media/api-reference/post-media-metadata-create so updating to match the v2 https://docs.x.com/x-api/media/metadata-create

Reported here https://github.com/PLhery/node-twitter-api-v2/issues/579#issuecomment-2747647429