### PR TITLE
Adapt uploadMedia to new endpoints for chunked media upload in V2

### DIFF
--- a/src/types/v2/media.v2.types.ts
+++ b/src/types/v2/media.v2.types.ts
@@ -1,22 +1,14 @@
 export type MediaV2MediaCategory = 'tweet_image' | 'tweet_video' | 'tweet_gif' | 'dm_image' | 'dm_video' | 'dm_gif' | 'subtitles';
 
 export interface MediaV2UploadInitParams {
-  command: 'INIT';
   media_type: string;
   total_bytes: number;
   media_category?: MediaV2MediaCategory;
 }
 
 export interface MediaV2UploadAppendParams {
-  command: 'APPEND';
-  media_id: string;
   segment_index: number;
   media: Buffer;
-}
-
-export interface MediaV2UploadFinalizeParams {
-  command: 'FINALIZE';
-  media_id: string;
 }
 
 export interface MediaV2ProcessingInfo {


### PR DESCRIPTION
As announced [here](https://devcommunity.x.com/t/media-upload-endpoints-update-and-extended-migration-deadline/241818), within the next 1-2 weeks, the command query parameter used for chunked uploads will be deprecated for the POST https://api.x.com/2/media/upload endpoint.

They will replace the single POST https://api.x.com/2/media/upload endpoint (previously using a commands query parameter with INIT, APPEND, and FINALIZE) with dedicated endpoints for each command:

- POST [https://api.x.com/2/media/upload/initialize](https://docs.x.com/x-api/media/media-upload-initialize)
- POST [https://api.x.com/2/media/upload/{id}/append](https://api.x.com/2/media/upload/:media_id/append)
- POST [https://api.x.com/2/media/upload/{id}/finalize](https://api.x.com/2/media/upload/:media_id/finalize)

In this PR I've adapted the code to upload media in V2 so that it uses the new dedicated endpoints.

The issue was reported here https://github.com/PLhery/node-twitter-api-v2/issues/569#issuecomment-2846697068