### PR TITLE
Fix uploadMedia for chunked media upload in V2 according to docs

### DIFF
--- a/src/types/v2/media.v2.types.ts
+++ b/src/types/v2/media.v2.types.ts
@@ -1,9 +1,10 @@
 export type MediaV2MediaCategory = 'tweet_image' | 'tweet_video' | 'tweet_gif' | 'dm_image' | 'dm_video' | 'dm_gif' | 'subtitles';
 
 export interface MediaV2UploadInitParams {
+  additional_owners?: string[];
+  media_category?: MediaV2MediaCategory;
   media_type: string;
   total_bytes: number;
-  media_category?: MediaV2MediaCategory;
 }
 
 export interface MediaV2UploadAppendParams {

--- a/src/types/v2/media.v2.types.ts
+++ b/src/types/v2/media.v2.types.ts
@@ -1,22 +1,14 @@
 export type MediaV2MediaCategory = 'tweet_image' | 'tweet_video' | 'tweet_gif' | 'dm_image' | 'dm_video' | 'dm_gif' | 'subtitles';
 
 export interface MediaV2UploadInitParams {
-  command: 'INIT';
   media_type: string;
   total_bytes: number;
   media_category?: MediaV2MediaCategory;
 }
 
 export interface MediaV2UploadAppendParams {
-  command: 'APPEND';
-  media_id: string;
   segment_index: number;
   media: Buffer;
-}
-
-export interface MediaV2UploadFinalizeParams {
-  command: 'FINALIZE';
-  media_id: string;
 }
 
 export interface MediaV2ProcessingInfo {


### PR DESCRIPTION
I applied the requested changes:

- `segment_index` starts at 1, as indicated in [docs.x.com/x-api/media/media-upload-append](https://docs.x.com/x-api/media/media-upload-append)
- Remove `{ forceBodyMode: 'form-data' }` since it is not necessary anymore
- Add `additional_owners` as an optional parameter (in MediaV2UploadInitParams)