### PR TITLE
Fix error handling and use segment_index starting from zero

### DIFF
--- a/src/client-mixins/request-handler.helper.ts
+++ b/src/client-mixins/request-handler.helper.ts
@@ -98,7 +98,7 @@ export class RequestHandlerHelper<T> {
     if (data?.errors?.length) {
       const errors = data.errors as (ErrorV1 | ErrorV2)[];
 
-      if ('code' in errors[0]) {
+      if (typeof errors[0] === 'object' && 'code' in errors[0]) {
         errorString += ' - ' + this.formatV1Errors(errors as ErrorV1[]);
       }
       else {

--- a/src/types/v2/media.v2.types.ts
+++ b/src/types/v2/media.v2.types.ts
@@ -1,9 +1,10 @@
 export type MediaV2MediaCategory = 'tweet_image' | 'tweet_video' | 'tweet_gif' | 'dm_image' | 'dm_video' | 'dm_gif' | 'subtitles';
 
 export interface MediaV2UploadInitParams {
+  additional_owners?: string[];
+  media_category?: MediaV2MediaCategory;
   media_type: string;
   total_bytes: number;
-  media_category?: MediaV2MediaCategory;
 }
 
 export interface MediaV2UploadAppendParams {

--- a/src/types/v2/media.v2.types.ts
+++ b/src/types/v2/media.v2.types.ts
@@ -1,22 +1,14 @@
 export type MediaV2MediaCategory = 'tweet_image' | 'tweet_video' | 'tweet_gif' | 'dm_image' | 'dm_video' | 'dm_gif' | 'subtitles';
 
 export interface MediaV2UploadInitParams {
-  command: 'INIT';
   media_type: string;
   total_bytes: number;
   media_category?: MediaV2MediaCategory;
 }
 
 export interface MediaV2UploadAppendParams {
-  command: 'APPEND';
-  media_id: string;
   segment_index: number;
   media: Buffer;
-}
-
-export interface MediaV2UploadFinalizeParams {
-  command: 'FINALIZE';
-  media_id: string;
 }
 
 export interface MediaV2ProcessingInfo {

--- a/src/v2/client.v2.write.ts
+++ b/src/v2/client.v2.write.ts
@@ -168,7 +168,7 @@ export default class TwitterApiv2ReadWrite extends TwitterApiv2ReadOnly {
       const chunkedBuffer = Buffer.from(mediaChunk);
 
       const appendArguments: MediaV2UploadAppendParams = {
-        segment_index: i + 1,
+        segment_index: i,
         media: chunkedBuffer,
       };
 


### PR DESCRIPTION
Fixes error handling using the `uploadMedia` function and rollbacks `segment_index` to start from zero instead of from one.