### PR TITLE
chore: add article as enum

### DIFF
--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -49,7 +49,7 @@ export type TTweetv2MediaField = 'duration_ms' | 'height' | 'media_key' | 'previ
   | 'url' | 'width' | 'public_metrics' | 'non_public_metrics' | 'organic_metrics' | 'alt_text' | 'variants';
 export type TTweetv2PlaceField = 'contained_within' | 'country' | 'country_code' | 'full_name' | 'geo' | 'id' | 'name' | 'place_type';
 export type TTweetv2PollField = 'duration_minutes' | 'end_datetime' | 'id' | 'options' | 'voting_status';
-export type TTweetv2TweetField = 'attachments' | 'author_id' | 'context_annotations' | 'conversation_id'
+export type TTweetv2TweetField = 'article' | 'attachments' | 'author_id' | 'context_annotations' | 'conversation_id'
   | 'created_at' | 'entities' | 'geo' | 'id' | 'in_reply_to_user_id' | 'lang'
   | 'public_metrics' | 'non_public_metrics' | 'promoted_metrics' | 'organic_metrics' | 'edit_controls'
   | 'possibly_sensitive' | 'referenced_tweets' | 'reply_settings' | 'source' | 'text' | 'withheld' | 'note_tweet' | 'edit_history_tweet_ids';


### PR DESCRIPTION
# Add 'article' to supported tweet.fields parameters

## Description

This PR adds 'article' to the `TTweetv2TweetField` type definition. The article field is a valid parameter for tweet.fields as documented in the X API documentation for [Full Archive Search](https://docs.x.com/x-api/posts/full-archive-search) and [Recent Search](https://docs.x.com/x-api/posts/recent-search).

This change enables users of the library to request article content in tweets, particularly useful for tweets that contain Notes.

## Changes

- Added 'article' to the `TTweetv2TweetField` type union in `src/types/v2/tweet.v2.types.ts`

## Impact

This change is:
- Backward compatible
- Purely additive
- Has no runtime impact
- Enhances type safety

## References

- [X API Full Archive Search Documentation](https://docs.x.com/x-api/posts/full-archive-search)
- [X API Recent Search Documentation](https://docs.x.com/x-api/posts/recent-search)