### PR TITLE
Add share_with_followers in SendTweetV2Params

### DIFF
--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -203,6 +203,7 @@ export interface SendTweetV2Params {
   reply_settings?: TTweetReplySettingsV2 | string;
   text?: string;
   community_id?: string;
+  share_with_followers?: 'True' | 'False';
 }
 
 //// FINALLY, TweetV2

--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -203,7 +203,7 @@ export interface SendTweetV2Params {
   reply_settings?: TTweetReplySettingsV2 | string;
   text?: string;
   community_id?: string;
-  share_with_followers?: 'True' | 'False';
+  share_with_followers?: boolean;
 }
 
 //// FINALLY, TweetV2


### PR DESCRIPTION
## Summary

When posting to communities, this makes the post to be shared with followers and show up on the timeline too.

## Official doc

https://docs.x.com/x-api/posts/create-post#body-share-with-followers