### PR TITLE
Avoid iterating prototype properties in trimUndefinedProperties

### DIFF
--- a/doc/helpers.md
+++ b/doc/helpers.md
@@ -17,6 +17,7 @@ This is a comprehensive guide of all helpers available for the Twitter API on bo
 	* [Usage without instantiation](#usage-without-instantiation)
 * [Extract errors in an array](#extract-errors-in-an-array)
 * [Change image size of a profile picture](#change-image-size-of-a-profile-picture)
+* [Remove undefined properties from objects](#remove-undefined-properties-from-objects)
 
 <!-- vscode-markdown-toc-config
 	numbering=false
@@ -214,4 +215,18 @@ const user = await client.currentUser();
 
 // Original profile img link
 const originalProfileImage = TwitterApi.getProfileImageInSize(user.profile_image_url_https, 'original');
+```
+
+## Remove undefined properties from objects
+
+Use `trimUndefinedProperties` to remove `undefined` values from an object's own enumerable properties.
+This helper iterates over keys returned by `Object.keys`, leaving properties defined on the prototype chain untouched.
+
+```ts
+const proto = { inherited: 'value' };
+const obj = Object.create(proto);
+obj.keep = 1;
+obj.toRemove = undefined;
+trimUndefinedProperties(obj);
+// obj is now { keep: 1 } and still inherits `inherited`
 ```

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -26,9 +26,10 @@ export function arrayWrap<T>(value: T | T[]) : T[] {
 
 export function trimUndefinedProperties(object: any) {
   // Delete undefined parameters
-  for (const parameter in object) {
-    if (object[parameter] === undefined)
+  for (const parameter of Object.keys(object)) {
+    if (object[parameter] === undefined) {
       delete object[parameter];
+    }
   }
 }
 

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,0 +1,29 @@
+import 'mocha';
+import { expect } from 'chai';
+import { trimUndefinedProperties } from '../src/helpers';
+
+describe('trimUndefinedProperties', () => {
+  it('does not access or delete properties from the prototype chain', () => {
+    let accessed = false;
+    const proto = {} as any;
+    Object.defineProperty(proto, 'inherited', {
+      enumerable: true,
+      get() {
+        accessed = true;
+        return undefined;
+      },
+    });
+
+    const obj = Object.create(proto);
+    obj.keep = 1;
+    obj.toRemove = undefined;
+
+    trimUndefinedProperties(obj);
+
+    expect(accessed).to.equal(false);
+    expect(obj).to.not.have.own.property('toRemove');
+    expect(obj.keep).to.equal(1);
+    expect('inherited' in obj).to.equal(true);
+    expect(Object.prototype.hasOwnProperty.call(obj, 'inherited')).to.equal(false);
+  });
+});


### PR DESCRIPTION
Created by codex

## Summary
- Ensure `trimUndefinedProperties` only iterates own keys to avoid touching prototype chain
- Document `trimUndefinedProperties` behavior and add example
- Add unit test confirming prototype properties are untouched

## Testing
- `npm run mocha test/helpers.test.ts`