### PR TITLE
docs: add ads API docs and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Learn how to use the full potential of `twitter-api-v2`.
   - [Handle errors](./doc/errors.md)
   - [Master `twitter-api-v2` paginators](./doc/paginators.md)
   - [Discover available helpers](./doc/helpers.md)
+- [Twitter Ads API (beta)](./doc/ads.md)
 
 ## Plugins
 

--- a/doc/ads.md
+++ b/doc/ads.md
@@ -1,0 +1,28 @@
+# Twitter Ads API (beta)
+
+The `twitter-api-v2` package includes experimental support for the Twitter Ads API.
+
+> **Beta note:** endpoint-specific helpers are not yet implemented. Use generic HTTP helpers such as `.get`, `.post`, `.put`, etc.
+
+## Authentication & Base URL
+
+The Ads API uses the same OAuth flows as the main client. Create a `TwitterApi` instance with your credentials and access the Ads client through `client.ads`.
+
+The client automatically prefixes requests with the appropriate Ads API base URL, so you don't need to manage the base URL yourself.
+
+```ts
+import { TwitterApi } from 'twitter-api-v2';
+
+const client = new TwitterApi({ /* your app credentials */ });
+
+// Access the Ads API
+const adsClient = client.ads;
+
+// Access the Ads Sandbox API
+const sandbox = client.ads.sandbox;
+
+// Use generic HTTP helpers
+const accounts = await adsClient.get('accounts');
+```
+
+The sandbox client uses the Ads sandbox base URL internally as well.

--- a/doc/v2.md
+++ b/doc/v2.md
@@ -1027,7 +1027,7 @@ for await (const mutedUser of mutedPaginator) {
 
 **Example**
 ```ts
-const mediaId = await client.v2.uploadMedia(Buffer.from('imgae.png'), { media_type: 'image/png' });
+const mediaId = await client.v2.uploadMedia(Buffer.from('image.png'), { media_type: 'image/png' });
 const newTweet = await client.v1.tweet('Hello!', { media_ids: mediaId });
 ```
 


### PR DESCRIPTION
Written by codex

## Summary
- add initial Twitter Ads API beta documentation and link in README
- correct `image.png` example in v2 upload media docs