### PR TITLE
docs: clarify usage endpoint

### DIFF
--- a/doc/v2.md
+++ b/doc/v2.md
@@ -1059,14 +1059,28 @@ await client.v2.createMediaMetadata(mediaId, { alt_text: { text: 'Hello, world!'
 
 **Right level**: `Read-only`
 
+**Scope**: App-only (no user OAuth scope required)
+
 **Arguments**:
   - `options: TweetUsageV2Params`
+
+`usage.fields` values: `cap_reset_day`, `daily_client_app_usage`, `daily_project_usage`, `project_cap`, `project_id`, `project_usage`.
 
 **Returns**: `TweetV2UsageResult`
 
 **Example**
 ```ts
-const usage = await client.v2.usage({ 'usage.fields': ['daily_project_usage'] });
+const usage = await client.v2.usage({ 'usage.fields': ['project_usage', 'project_cap'] });
+```
+
+**Example result**
+```json
+{
+  "data": {
+    "project_usage": "123",
+    "project_cap": "1000"
+  }
+}
 ```
 
 ## Lists

--- a/src/types/v2/community.v2.types.ts
+++ b/src/types/v2/community.v2.types.ts
@@ -31,4 +31,4 @@ export interface CommunitySearchV2Params {
   max_results?: number;
   next_token?: string;
   pagination_token?: string;
-} 
+}

--- a/src/v2/client.v2.read.ts
+++ b/src/v2/client.v2.read.ts
@@ -873,7 +873,7 @@ export default class TwitterApiv2ReadOnly extends TwitterApiSubClient {
 
   /**
    * Allows you to retrieve your project usage.
-   * 
+   *
    * https://developer.x.com/en/docs/x-api/usage/tweets/introduction
    */
   public async usage(options: Partial<TweetUsageV2Params> = {}) {


### PR DESCRIPTION
Written by codex

## Summary
- document available `usage.fields` values and note that Tweet usage is app-only
- include an example of retrieving `project_usage` and `project_cap`