### PR TITLE
Add edit controls to TweetV2 type

### DIFF
--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -168,6 +168,12 @@ export interface TweetOrganicMetricsV2 {
 
 export type TweetPromotedMetricsV2 = TweetOrganicMetricsV2;
 
+export interface EditControlsV2 {
+  editable_until: string;
+  edits_remaining: number;
+  is_edit_eligible: boolean;
+}
+
 export interface NoteTweetV2 {
   text: string;
   entities?: NoteTweetEntitiesV2;
@@ -225,6 +231,7 @@ export interface TweetV2 {
   non_public_metrics?: TweetNonPublicMetricsV2;
   organic_metrics?: TweetOrganicMetricsV2;
   promoted_metrics?: TweetPromotedMetricsV2;
+  edit_controls?: EditControlsV2;
   possibly_sensitive?: boolean;
   lang?: string;
   reply_settings?: 'everyone' | 'mentionedUsers' | 'following';


### PR DESCRIPTION
## Summary
- define `EditControlsV2` interface and expose it on `TweetV2`
- allow requesting `edit_controls` in tweet fields

## Testing
- `npm test` *(fails: Invalid consumer tokens)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ef3182cc8332a8e7afb2e8220c2c