### PR TITLE
feat(stream): support delete_all query for stream rules

### DIFF
--- a/doc/streaming.md
+++ b/doc/streaming.md
@@ -216,6 +216,9 @@ const deleteRules = await client.v2.updateStreamRules({
     ids: ['281646', '1534843'],
   },
 });
+
+// Delete all rules
+await client.v2.updateStreamRules({}, { delete_all: true });
 ```
 
 ### Sample endpoint

--- a/src/types/v2/streaming.v2.types.ts
+++ b/src/types/v2/streaming.v2.types.ts
@@ -52,7 +52,13 @@ export interface StreamingV2DeleteRulesParams {
   };
 }
 
-export type StreamingV2UpdateRulesParams = StreamingV2AddRulesParams | StreamingV2DeleteRulesParams;
+/** Empty body used when deleting all rules through the `delete_all` query parameter. */
+export type StreamingV2DeleteAllRulesParams = Record<string, never>;
+
+export type StreamingV2UpdateRulesParams =
+  | StreamingV2AddRulesParams
+  | StreamingV2DeleteRulesParams
+  | StreamingV2DeleteAllRulesParams;
 
 export interface StreamingV2UpdateRulesQuery {
   /**
@@ -60,6 +66,11 @@ export interface StreamingV2UpdateRulesQuery {
    * This is useful if you want to check the syntax of a rule before removing one or more of your existing rules.
    */
   dry_run: boolean;
+  /**
+   * Delete all of the rules associated with this client app. It should be specified with no other parameters.
+   * Once deleted, rules cannot be recovered.
+   */
+  delete_all?: boolean;
 }
 
 export type StreamingV2UpdateRulesAddResult = DataAndMetaV2<StreamingV2Rule[], {


### PR DESCRIPTION
Created by codex

## Summary
- allow using `delete_all` query to remove all stream rules
- document how to delete all rules using `updateStreamRules`