### PR TITLE
Add amplify_video media category for v2 uploads

### DIFF
--- a/src/types/v2/media.v2.types.ts
+++ b/src/types/v2/media.v2.types.ts
@@ -1,4 +1,4 @@
-export type MediaV2MediaCategory = 'tweet_image' | 'tweet_video' | 'tweet_gif' | 'dm_image' | 'dm_video' | 'dm_gif' | 'subtitles';
+export type MediaV2MediaCategory = 'tweet_image' | 'tweet_video' | 'tweet_gif' | 'dm_image' | 'dm_video' | 'dm_gif' | 'subtitles' | 'amplify_video';
 
 export interface MediaV2UploadInitParams {
   additional_owners?: string[];


### PR DESCRIPTION
## Summary
- add missing `amplify_video` media category type for Twitter Ads API media uploads

## Testing
- `npm test` *(fails: Invalid consumer tokens)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9ff5f344c8332a65450286d1526a1