### PR TITLE
docs: clarify reply and quotes

### DIFF
--- a/doc/streaming.md
+++ b/doc/streaming.md
@@ -12,7 +12,8 @@ This lib supports streaming for v1 and v2 API.
 	* [Search endpoint](#search-endpoint)
 	* [Search endpoint - Get applied rules](#search-endpoint---get-applied-rules)
 	* [Search endpoint - Add or delete rules](#search-endpoint---add-or-delete-rules)
-	* [Sample endpoint](#sample-endpoint-1)
+        * [Sample endpoint](#sample-endpoint-1)
+        * [Sample 10% endpoint](#sample-10-endpoint)
 * [Make a custom request](#make-a-custom-request)
 * [`TweetStream` reference](#tweetstream-reference)
 	* [Methods / properties](#methods--properties)
@@ -237,6 +238,33 @@ const client = ...; // (create a Bearer OAuth2 client)
 const stream = await client.v2.sampleStream();
 
 // Event data will be tweets of v2 API.
+```
+
+### Sample 10% endpoint
+
+Streams approximately 10% of the public tweet volume in real time.
+
+Method: **`v2.sample10Stream()`**.
+
+Endpoint: `tweets/sample10/stream`.
+
+Reference: https://developer.x.com/en/docs/twitter-api/tweets/volume-streams/api-reference/get-tweets-sample10-stream
+
+Level: **Read-only**.
+
+Arguments: `options?: Partial<Tweetv2FieldsParams> & { autoConnect?: boolean }`.
+
+Returns: `TweetStream<TweetV2SingleResult>`.
+
+```ts
+const stream = await client.v2.sample10Stream();
+for await (const { data } of stream) {
+  console.log(data.id);
+}
+// or create a non-auto-connected stream:
+const stream = client.v2.sample10Stream({ autoConnect: false });
+stream.on(ETwitterStreamEvent.Data, console.log);
+await stream.connect({ autoReconnect: true });
 ```
 
 ## Make a custom request

--- a/doc/v2.md
+++ b/doc/v2.md
@@ -42,7 +42,7 @@ This is a comprehensive guide of all methods available for the Twitter API v2 on
     - [Get users that retweeted a specific tweet](#get-users-that-retweeted-a-specific-tweet)
     - [Retweet a tweet](#retweet-a-tweet)
     - [Unretweet a tweet](#unretweet-a-tweet)
-    - [List quoted replies of a tweet](#list-quoted-replies-of-a-tweet)
+    - [List quote tweets of a tweet](#list-quote-tweets-of-a-tweet)
   - [Bookmarks](#bookmarks)
     - [Bookmark a tweet](#bookmark-a-tweet)
     - [Remove bookmark](#remove-bookmark)
@@ -268,7 +268,7 @@ console.log('Tweet', createdTweet.id, ':', createdTweet.text);
 
 ### Reply to a tweet
 
-Alias to a `.tweet` with `in_reply_to_tweet_id` already set.
+Alias to `.tweet()` with `reply: { in_reply_to_tweet_id: tweetId }` already set.
 
 **Method**: `.reply()`
 
@@ -277,9 +277,9 @@ Alias to a `.tweet` with `in_reply_to_tweet_id` already set.
 **Right level**: `Read-write`
 
 **Arguments**:
-  - `status: string`
-  - `in_reply_to_status_id: string`
-  - `payload?: SendTweetV2Params`
+  - `status: string` – text of the reply.
+  - `tweetId: string` – ID of the tweet you want to reply to (sets `in_reply_to_tweet_id` in the payload).
+  - `payload?: SendTweetV2Params` – optional additional parameters (e.g., media, geolocation).
 
 **Returns**: `TweetV2PostTweetResult`
 
@@ -607,9 +607,9 @@ Remove a retweet of a single tweet.
 await client.v2.unretweet('12', '20');
 ```
 
-### List quoted replies of a tweet
+### List quote tweets of a tweet
 
-List quoted replies of a tweets using a tweet paginator.
+Retrieve quote tweets for a single tweet using a paginator.
 
 **Method**: `.quotes()`
 
@@ -618,20 +618,24 @@ List quoted replies of a tweets using a tweet paginator.
 **Right level**: `Read-only`
 
 **Arguments**:
-  - `tweetId: string`: Tweet ID
-  - `options: TweetV2PaginableTimelineParams`: Tweet meta options
+  - `tweetId: string` – ID of the tweet whose quote tweets you want.
+  - `options?: TweetV2PaginableTimelineParams` – optional fields/expansions.
 
 **Returns**: `QuotedTweetsTimelineV2Paginator`: A tweet paginator
 
 **Example**
 ```ts
-const quotes = await client.v2.quotes({ expansions: ['author_id'], 'user.fields': ['username', 'url'] })
+// Fetch quote tweets for a given tweet ID
+const quotes = await client.v2.quotes('1456789', {
+  expansions: ['author_id'],
+  'user.fields': ['username', 'url'],
+});
 
 for await (const quote of quotes) {
-  const quotedTweetAuthor = bookmarks.includes.author(quote)
-
-  if (quotedTweetAuthor) {
-    console.log('Quote answer tweet', quote.id, 'has been made by', quotedTweetAuthor.username)
+  // Access the author using the paginator’s includes helper
+  const author = quotes.includes.author(quote);
+  if (author) {
+    console.log(`${quote.id} quoted by ${author.username}`);
   }
 }
 ```

--- a/src/v1/client.v1.write.ts
+++ b/src/v1/client.v1.write.ts
@@ -244,7 +244,7 @@ export default class TwitterApiv1ReadWrite extends TwitterApiv1ReadOnly {
   }
 
   /**
-   * Removes multiple members to a list, by specifying a comma-separated list of member ids or screen names.
+   * Removes one or more members from a list, by specifying a comma-separated list of member ids or screen names.
    * If you add a single `user_id` or `screen_name`, it will target `lists/members/destroy.json`, otherwise
    * it will target `lists/members/destroy_all.json`.
    * https://developer.x.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-members-destroy_all


### PR DESCRIPTION
Created by codex

## Summary
- refine `.reply()` docs to use `tweetId` and clarify alias behaviour
- fix quote tweets section and example
- document new `sample10Stream` endpoint
- clarify list member removal comment