### PR TITLE
fix: remove circular import in TwitterApiReadOnly

### DIFF
--- a/src/client/readonly.ts
+++ b/src/client/readonly.ts
@@ -1,4 +1,4 @@
-import TwitterApi from '.';
+import type TwitterApi from '.';
 import TwitterApiBase from '../client.base';
 import {
   AccessOAuth2TokenArgs,
@@ -151,7 +151,7 @@ export default class TwitterApiReadOnly extends TwitterApiBase {
       { oauth_token: tokens.accessToken, oauth_verifier }
     );
 
-    const client = new TwitterApi({
+    const client = new (this.constructor as typeof TwitterApi)({
       appKey: tokens.appKey,
       appSecret: tokens.appSecret,
       accessToken: oauth_result.oauth_token,
@@ -185,11 +185,11 @@ export default class TwitterApiReadOnly extends TwitterApiBase {
       throw new Error('You must setup TwitterApi instance with consumer keys to accept app-only login');
 
     // Create a client with Basic authentication
-    const basicClient = new TwitterApi({ username: tokens.appKey, password: tokens.appSecret }, this._requestMaker.clientSettings);
+    const basicClient = new (this.constructor as typeof TwitterApi)({ username: tokens.appKey, password: tokens.appSecret }, this._requestMaker.clientSettings);
     const res = await basicClient.post<BearerTokenResult>('https://api.x.com/oauth2/token', { grant_type: 'client_credentials' });
 
     // New object with Bearer token
-    return new TwitterApi(res.access_token, this._requestMaker.clientSettings);
+    return new (this.constructor as typeof TwitterApi)(res.access_token, this._requestMaker.clientSettings);
   }
 
   /* OAuth 2 user authentication */
@@ -356,7 +356,7 @@ export default class TwitterApiReadOnly extends TwitterApiBase {
   }
 
   protected parseOAuth2AccessTokenResult(result: AccessOAuth2TokenResult): IParsedOAuth2TokenResult {
-    const client = new TwitterApi(result.access_token, this._requestMaker.clientSettings);
+    const client = new (this.constructor as typeof TwitterApi)(result.access_token, this._requestMaker.clientSettings);
     const scope = result.scope.split(' ').filter(e => e) as TOAuth2Scope[];
 
     return {


### PR DESCRIPTION
Created by codex

## Summary
- avoid circular dependency in `TwitterApiReadOnly` by using type-only import and `this.constructor`

## Testing
- `npm run lint`

Fixes #531 (tested)