### PR TITLE
fix: remove unsupported previous_token from search params

### DIFF
--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -21,7 +21,6 @@ export interface TweetV2TimelineParams extends Partial<Tweetv2FieldsParams> {
 }
 
 export interface Tweetv2SearchParams extends TweetV2TimelineParams {
-  previous_token?: string;
   query: string;
   sort_order?: 'recency' | 'relevancy';
 }


### PR DESCRIPTION
Created by codex

## Summary
- remove `previous_token` from `Tweetv2SearchParams` as the search endpoint does not accept it

Fixes #597