### PR TITLE
feat: support stream rule pagination

### DIFF
--- a/doc/streaming.md
+++ b/doc/streaming.md
@@ -178,10 +178,21 @@ Level: **Read-only**.
 
 Returns: **`StreamingV2GetRulesResult`**.
 
+You can limit the number of rules returned per page with `max_results` (min 1, max 1000, default 1000) and paginate using `pagination_token`.
+
 ```ts
 const client = ...; // (create a Bearer OAuth2 client)
 
-const rules = await client.v2.streamRules();
+// Retrieve up to 500 rules per page
+const rules = await client.v2.streamRules({ max_results: 500 });
+
+// Fetch next page if a next_token is present
+if (rules.meta.next_token) {
+  const nextPage = await client.v2.streamRules({
+    pagination_token: rules.meta.next_token,
+    max_results: 500,
+  });
+}
 
 // Log every rule ID
 console.log(rules.data.map(rule => rule.id));

--- a/src/types/v2/streaming.v2.types.ts
+++ b/src/types/v2/streaming.v2.types.ts
@@ -4,11 +4,15 @@
 
 // -- Get stream rules --
 
-import { DataAndMetaV2, MetaV2, SentMeta } from './shared.v2.types';
+import { DataAndMetaV2, MetaV2, PaginableCountMetaV2, SentMeta } from './shared.v2.types';
 
 export interface StreamingV2GetRulesParams {
   /** Comma-separated list of rule IDs. If omitted, all rules are returned. */
-  ids: string;
+  ids?: string;
+  /** Maximum number of rules to return. Min 1, max 1000, default 1000. */
+  max_results?: number;
+  /** Token to retrieve the next page of results. */
+  pagination_token?: string;
 }
 
 export interface StreamingV2Rule {
@@ -20,7 +24,7 @@ export interface StreamingV2Rule {
   tag?: string;
 }
 
-export type StreamingV2GetRulesResult = DataAndMetaV2<StreamingV2Rule[], SentMeta>;
+export type StreamingV2GetRulesResult = DataAndMetaV2<StreamingV2Rule[], PaginableCountMetaV2>;
 
 // -- Add / delete stream rules --
 


### PR DESCRIPTION
Created by Codex

## Summary
- allow passing `pagination_token` and `max_results` to `v2.streamRules`
- expose pagination metadata in `StreamingV2GetRulesResult`
- document how to paginate stream rules and limit results per page

Fixes #537 