### PR TITLE
Fix coordinate types

### DIFF
--- a/src/types/v1/entities.v1.types.ts
+++ b/src/types/v1/entities.v1.types.ts
@@ -109,9 +109,12 @@ export interface PollPositionV1 {
 }
 
 /** See GeoJSON. */
-export interface CoordinateV1 {
-  coordinates: number[] | number[][];
-  type: string;
+export type CoordinateV1 = {
+  coordinates: number[];
+  type: "Point";
+} | {
+  coordinates: number[][][];
+  type: "Polygon";
 }
 
 export interface PlaceV1 {


### PR DESCRIPTION
Tweet coordinate can be of two types:
1. Point, array of numbers. Examples: https://developer.x.com/en/docs/x-api/v1/direct-messages/message-attachments/guides/attaching-location
<img width="446" height="236" alt="image" src="https://github.com/user-attachments/assets/2a11ef15-c0dd-4d0c-8b8e-017668396c19" />

2. Polygon, Array of Array of Array of Float.
See bounding box https://developer.x.com/en/docs/x-api/v1/data-dictionary/object-model/geo#coordinates-dictionary

I didn't find anywhere where it can be number[][], only number[] and number[][][]