### PR TITLE
fix: Add back the article tweet field

### DIFF
--- a/src/types/v2/tweet.definition.v2.ts
+++ b/src/types/v2/tweet.definition.v2.ts
@@ -183,6 +183,11 @@ export type NoteTweetEntitiesV2 = Omit<TweetEntitiesV2, 'annotations'>;
 
 export type TTweetReplySettingsV2 = 'mentionedUsers' | 'following' | 'everyone';
 
+export interface TweetArticleV2 {
+  cover_media?: MediaObjectV2;
+  media_entities?: MediaObjectV2[];
+}
+
 export interface SendTweetV2Params {
   direct_message_deep_link?: string;
   for_super_followers_only?: 'True' | 'False';
@@ -238,6 +243,7 @@ export interface TweetV2 {
   source?: string;
   note_tweet?: NoteTweetV2;
   community_id?: string;
+  article?: TweetArticleV2;
 }
 
 export interface ApiV2Includes {

--- a/src/types/v2/tweet.v2.types.ts
+++ b/src/types/v2/tweet.v2.types.ts
@@ -39,11 +39,13 @@ export interface TweetV2UserTimelineParams extends TweetV2PaginableTimelineParam
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface TweetV2HomeTimelineParams extends TweetV2UserTimelineParams {}
+export interface TweetV2HomeTimelineParams extends TweetV2UserTimelineParams { }
 
-export type TTweetv2Expansion = 'attachments.poll_ids' | 'attachments.media_keys'
+export type TTweetv2Expansion = 'attachments.poll_ids' | 'attachments.media_keys' | 'attachments.media_source_tweet'
   | 'author_id' | 'referenced_tweets.id' | 'in_reply_to_user_id' | 'edit_history_tweet_ids'
-  | 'geo.place_id' | 'entities.mentions.username' | 'referenced_tweets.id.author_id';
+  | 'geo.place_id' | 'entities.mentions.username' | 'referenced_tweets.id.author_id'
+  | 'article.cover_media' | 'article.media_entities'
+  | 'entities.note.mentions.username' | 'referenced_tweets.id.attachments.media_keys';
 export type TTweetv2MediaField = keyof MediaObjectV2;
 export type TTweetv2PlaceField = keyof PlaceV2;
 export type TTweetv2PollField = keyof PollV2;


### PR DESCRIPTION
Fixes #627

Add back the article field to TTweetv2TweetField, by adding it to the actual tweetsV2 interface

(source https://api.twitter.com/2/openapi.json and https://docs.x.com/x-api/posts/search-recent-posts)